### PR TITLE
add mongo transactions so operations can rollback db state on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ This is actually pretty easy, you basically need a Hive account and that's it. T
 
 see wiki: https://github.com/harpagon210/steemsmartcontracts/wiki/How-to-setup-a-Steem-Smart-Contracts-node
 
+In addition, the followimg is needed to use transaction framework for MongoDB:
+- Run MongoDB in replicated mode. This is as simple as changing the mongo config to add replication config:
+  ```
+    replication:
+      replSetName: "rs0"
+  ```
+- Need version 3.6 mongo node library.
 ## 5. Tests
 * npm run test
 

--- a/contracts/testing/badaction.js
+++ b/contracts/testing/badaction.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-await-in-loop */
+/* eslint-disable quote-props */
+/* global actions, api */
+
+actions.createSSC = async () => {
+  await api.db.createTable('test');
+};
+
+actions.insertAndError = async () => {
+  await api.db.insert('test', {a: 1});
+  api.assert(false, 'Error condition');
+};

--- a/contracts/testing/baddeploy.js
+++ b/contracts/testing/baddeploy.js
@@ -1,0 +1,10 @@
+/* eslint-disable no-await-in-loop */
+/* eslint-disable quote-props */
+/* global actions, api */
+
+actions.createSSC = async () => {
+  await api.db.createTable('test');
+
+  await api.db.insert('test', { a: 1 });
+  api.assert(false, 'Error condition');
+};

--- a/libs/Block.js
+++ b/libs/Block.js
@@ -175,7 +175,7 @@ class Block {
         const authorizedAccountContractDeployment = ['null', CONSTANTS.HIVE_ENGINE_ACCOUNT, CONSTANTS.HIVE_PEGGED_ACCOUNT];
 
         if (authorizedAccountContractDeployment.includes(sender)) {
-          results = await SmartContracts.deploySmartContract( // eslint-disable-line
+          results = await SmartContracts.deploySmartContractInTransaction( // eslint-disable-line
             database, transaction, this.blockNumber, this.timestamp,
             this.refHiveBlockId, this.prevRefHiveBlockId, jsVMTimeout,
           );
@@ -183,7 +183,7 @@ class Block {
           results = { logs: { errors: ['the contract deployment is currently unavailable'] } };
         }
       } else {
-        results = await SmartContracts.executeSmartContract(// eslint-disable-line
+        results = await SmartContracts.executeSmartContractInTransaction(// eslint-disable-line
           database, transaction, this.blockNumber, this.timestamp,
           this.refHiveBlockId, this.prevRefHiveBlockId, jsVMTimeout,
         );

--- a/libs/Database.js
+++ b/libs/Database.js
@@ -74,7 +74,7 @@ class Database {
 
   async init(databaseURL, databaseName) {
     // init the database
-    this.client = await MongoClient.connect(databaseURL, { useNewUrlParser: true });
+    this.client = await MongoClient.connect(databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
     this.database = await this.client.db(databaseName);
     // await database.dropDatabase();
     // return

--- a/package-lock.json
+++ b/package-lock.json
@@ -288,6 +288,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -741,6 +750,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -2260,29 +2274,22 @@
       }
     },
     "mongodb": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.6.tgz",
-      "integrity": "sha512-qnHc4tjEkHKemuzBq9R7ycYnhFE0Dlpt6+n6suoZp2DcDdqviQ+teloJU24fsOw/PLmr75yGk4mRx/YabjDQEQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.2.tgz",
+      "integrity": "sha512-sSZOb04w3HcnrrXC82NEh/YGCmBuRgR+C1hZgmmv4L6dBz4BkRse6Y8/q/neXer9i95fKUBbFi4KgeceXmbsOA==",
       "requires": {
-        "mongodb-core": "3.2.6",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "mongodb-core": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.2.6.tgz",
-      "integrity": "sha512-i+XRVjur9D0ywGF7cFebOUnALnbvMHajdNhhl3TQuopW6QDE655G8CpPeERbqSqfa3rOKEUo08lENDIiBIuAvQ==",
-      "requires": {
-        "bson": "^1.1.1",
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       },
       "dependencies": {
         "bson": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
-          "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "jayson": "^2.1.1",
     "js-base64": "^2.5.1",
     "line-by-line": "^0.1.6",
-    "mongodb": "^3.2.6",
+    "mongodb": "^3.6",
     "read-last-lines": "^1.6.0",
     "seedrandom": "^3.0.1",
     "socket.io": "^2.3.0",

--- a/test/botcontroller.js
+++ b/test/botcontroller.js
@@ -216,7 +216,7 @@ describe('botcontroller', function() {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/crittermanager.js
+++ b/test/crittermanager.js
@@ -142,7 +142,7 @@ describe('crittermanager', function() {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/dice.js
+++ b/test/dice.js
@@ -137,7 +137,7 @@ describe.skip('dice', function() {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/error_cases.js
+++ b/test/error_cases.js
@@ -1,0 +1,268 @@
+/* eslint-disable */
+const { fork } = require('child_process');
+const assert = require('assert');
+const fs = require('fs-extra');
+const BigNumber = require('bignumber.js');
+const { Base64 } = require('js-base64');
+const { MongoClient } = require('mongodb');
+
+
+const { Database } = require('../libs/Database');
+const blockchain = require('../plugins/Blockchain');
+const { Transaction } = require('../libs/Transaction');
+
+const { CONSTANTS } = require('../libs/Constants');
+
+const conf = {
+  chainId: "test-chain-id",
+  genesisSteemBlock: 2000000,
+  dataDirectory: "./test/data/",
+  databaseFileName: "database.db",
+  autosaveInterval: 0,
+  javascriptVMTimeout: 10000,
+  databaseURL: "mongodb://localhost:27017",
+  databaseName: "testssc",
+  streamNodes: ["https://api.steemit.com"],
+};
+
+let plugins = {};
+let jobs = new Map();
+let currentJobId = 0;
+let database1 = null;
+
+function send(pluginName, from, message) {
+  const plugin = plugins[pluginName];
+  const newMessage = {
+    ...message,
+    to: plugin.name,
+    from,
+    type: 'request',
+  };
+  currentJobId += 1;
+  newMessage.jobId = currentJobId;
+  plugin.cp.send(newMessage);
+  return new Promise((resolve) => {
+    jobs.set(currentJobId, {
+      message: newMessage,
+      resolve,
+    });
+  });
+}
+
+
+// function to route the IPC requests
+const route = (message) => {
+  const { to, type, jobId } = message;
+  if (to) {
+    if (to === 'MASTER') {
+      if (type && type === 'request') {
+        // do something
+      } else if (type && type === 'response' && jobId) {
+        const job = jobs.get(jobId);
+        if (job && job.resolve) {
+          const { resolve } = job;
+          jobs.delete(jobId);
+          resolve(message);
+        }
+      }
+    } else if (type && type === 'broadcast') {
+      plugins.forEach((plugin) => {
+        plugin.cp.send(message);
+      });
+    } else if (plugins[to]) {
+      plugins[to].cp.send(message);
+    } else {
+      console.error('ROUTING ERROR: ', message);
+    }
+  }
+};
+
+const loadPlugin = (newPlugin) => {
+  const plugin = {};
+  plugin.name = newPlugin.PLUGIN_NAME;
+  plugin.cp = fork(newPlugin.PLUGIN_PATH, [], { silent: true });
+  plugin.cp.on('message', msg => route(msg));
+  plugin.cp.stdout.on('data', data => console.log(`[${newPlugin.PLUGIN_NAME}]`, data.toString()));
+  plugin.cp.stderr.on('data', data => console.error(`[${newPlugin.PLUGIN_NAME}]`, data.toString()));
+
+  plugins[newPlugin.PLUGIN_NAME] = plugin;
+
+  return send(newPlugin.PLUGIN_NAME, 'MASTER', { action: 'init', payload: conf });
+};
+
+const unloadPlugin = (plugin) => {
+  plugins[plugin.PLUGIN_NAME].cp.kill('SIGINT');
+  plugins[plugin.PLUGIN_NAME] = null;
+  jobs = new Map();
+  currentJobId = 0;
+}
+
+function setupContractPayload(file) {
+  let contractCode = fs.readFileSync(file);
+  contractCode = contractCode.toString();
+  contractCode = contractCode.replace(/'\$\{CONSTANTS.UTILITY_TOKEN_PRECISION\}\$'/g, CONSTANTS.UTILITY_TOKEN_PRECISION);
+  contractCode = contractCode.replace(/'\$\{CONSTANTS.UTILITY_TOKEN_SYMBOL\}\$'/g, CONSTANTS.UTILITY_TOKEN_SYMBOL);
+  contractCode = contractCode.replace(/'\$\{CONSTANTS.HIVE_PEGGED_SYMBOL\}\$'/g, CONSTANTS.HIVE_PEGGED_SYMBOL);
+
+  let base64ContractCode = Base64.encode(contractCode);
+
+  return {
+    name: 'bad',
+    params: '',
+    code: base64ContractCode,
+  };
+}
+
+const badDeployContractPayload = setupContractPayload('./contracts/testing/baddeploy.js');
+const badActionContractPayload = setupContractPayload('./contracts/testing/badaction.js');
+
+function assertError(tx, message) {
+  const logs = JSON.parse(tx.logs);
+  assert(logs.errors, 'No error in logs. Error expected with message ' + message);
+  assert.equal(logs.errors[0], message, `Error expected with message ${message}. Instead got ${logs.errors[0]}`);
+}
+
+async function assertNoErrorInLastBlock() {
+  const transactions = (await database1.getLatestBlockInfo()).transactions;
+  for (let i = 0; i < transactions.length; i++) {
+    const logs = JSON.parse(transactions[i].logs);
+    assert(!logs.errors, `Tx #${i} had unexpected error ${logs.errors}`);
+  }
+}
+
+// tokens
+describe('Bad smart contract', function () {
+  this.timeout(10000);
+
+  before((done) => {
+    new Promise(async (resolve) => {
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      db = await client.db(conf.databaseName);
+      await db.dropDatabase();
+      resolve();
+    })
+      .then(() => {
+        done()
+      })
+  });
+  
+  after((done) => {
+    new Promise(async (resolve) => {
+      await client.close();
+      resolve();
+    })
+      .then(() => {
+        done()
+      })
+  });
+
+  beforeEach((done) => {
+    new Promise(async (resolve) => {
+      db = await client.db(conf.databaseName);
+      resolve();
+    })
+      .then(() => {
+        done()
+      })
+  });
+
+  afterEach((done) => {
+      // runs after each test in this block
+      new Promise(async (resolve) => {
+        await db.dropDatabase()
+        resolve();
+      })
+        .then(() => {
+          done()
+        })
+  });
+
+  it('reverts partial writes on error', (done) => {
+    new Promise(async (resolve) => {
+      
+      await loadPlugin(blockchain);
+      database1 = new Database();
+      await database1.init(conf.databaseURL, conf.databaseName);
+
+      let transactions = [];
+      transactions.push(new Transaction(12345678901, 'TXID1233', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(badDeployContractPayload)));
+
+      let block = {
+        refHiveBlockNumber: 12345678901,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: block });
+
+      let lastBlock = await database1.getLatestBlockInfo();
+      let txs = lastBlock.transactions;
+      assertError(txs[0], 'Error condition');
+
+      let res = await database1.findOne({
+          contract: 'bad',
+          table: 'test',
+          query: {
+          }
+        });
+
+      assert(!res, 'No data expected');
+
+      transactions = [];
+      transactions.push(new Transaction(12345678902, 'TXID1234', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(badActionContractPayload)));
+
+      block = {
+        refHiveBlockNumber: 12345678902,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: block });
+
+      await assertNoErrorInLastBlock();
+
+      res = await database1.findContract({name: 'bad'});
+      assert(res, 'Inserted contract expected');
+        console.log(res);
+
+      transactions = [];
+      transactions.push(new Transaction(12345678903, 'TXID1235', 'harpagon', 'bad', 'insertAndError', ''));
+
+      block = {
+        refHiveBlockNumber: 12345678903,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: block });
+
+      lastBlock = await database1.getLatestBlockInfo();
+
+      txs = lastBlock.transactions;
+      assertError(txs[0], 'Error condition');
+
+      res = await database1.findOne({
+          contract: 'bad',
+          table: 'test',
+          query: {
+          }
+        });
+
+      assert(!res, 'No data expected');
+
+      resolve();
+    })
+      .then(() => {
+        unloadPlugin(blockchain);
+        database1.close();
+        done();
+      });
+  });
+
+});

--- a/test/hivepegged.js
+++ b/test/hivepegged.js
@@ -126,7 +126,7 @@ describe('Hive Pegged', function () {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/hivesmartcontracts.js
+++ b/test/hivesmartcontracts.js
@@ -233,7 +233,7 @@ describe('Smart Contracts', function ()  {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/market.js
+++ b/test/market.js
@@ -136,7 +136,7 @@ describe('Market', function() {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/nft.js
+++ b/test/nft.js
@@ -191,7 +191,7 @@ describe('nft', function() {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/nftmarket.js
+++ b/test/nftmarket.js
@@ -142,7 +142,7 @@ describe('nftmarket', function() {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/smarttokens.js
+++ b/test/smarttokens.js
@@ -117,7 +117,7 @@ describe('smart tokens', function () {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/sscstore.js
+++ b/test/sscstore.js
@@ -100,7 +100,7 @@ describe.skip('sscstore smart contract', function() {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -126,7 +126,7 @@ describe('Tokens smart contract', function () {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -112,6 +112,14 @@ let contractPayload = {
   code: base64ContractCode,
 };
 
+async function assertNoErrorInLastBlock() {
+  const transactions = (await database1.getLatestBlockInfo()).transactions;
+  for (let i = 0; i < transactions.length; i++) {
+    const logs = JSON.parse(transactions[i].logs);
+    assert(!logs.errors, `Tx #${i} had unexpected error ${logs.errors}`);
+  }
+}
+
 // tokens
 describe('Tokens smart contract', function () {
   this.timeout(10000);
@@ -292,7 +300,7 @@ describe('Tokens smart contract', function () {
 
       let transactions = [];
       transactions.push(new Transaction(12345678901, 'TXID1233', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(contractPayload)));
-      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": 0.001 }'));
+      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": "0.001" }'));
       transactions.push(new Transaction(30896501, 'TXID1234', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN.TEST", "precision": 3, "maxSupply": "1000", "isSignedWithActiveKey": true  }'));
 
       let block = {
@@ -304,6 +312,7 @@ describe('Tokens smart contract', function () {
       };
 
       await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: block });
+      await assertNoErrorInLastBlock();
 
       transactions = [];
       transactions.push(new Transaction(30896502, 'TXID1237', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateUrl', '{ "symbol": "TKN.TEST", "url": "https://new.token.com" }'));
@@ -317,6 +326,7 @@ describe('Tokens smart contract', function () {
       };
 
       await send(blockchain.PLUGIN_NAME, 'MASTER', { action: blockchain.PLUGIN_ACTIONS.PRODUCE_NEW_BLOCK_SYNC, payload: block });
+      await assertNoErrorInLastBlock();
 
       const res = await database1.findOne({
           contract: 'tokens',
@@ -348,7 +358,7 @@ describe('Tokens smart contract', function () {
 
       let transactions = [];
       transactions.push(new Transaction(12345678901, 'TXID1233', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(contractPayload)));
-      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": 0.001 }'));
+      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": "0.001" }'));
       transactions.push(new Transaction(30896501, 'TXID1234', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN.TEST", "precision": 3, "maxSupply": "1000", "isSignedWithActiveKey": true  }'));
 
       let block = {
@@ -411,7 +421,7 @@ describe('Tokens smart contract', function () {
 
       let transactions = [];
       transactions.push(new Transaction(12345678901, 'TXID1233', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(contractPayload)));
-      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": 0.001 }'));
+      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": "0.001" }'));
       transactions.push(new Transaction(30896501, 'TXID1234', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN.TEST", "precision": 3, "maxSupply": "1000", "isSignedWithActiveKey": true  }'));
 
       let block = {
@@ -469,7 +479,7 @@ describe('Tokens smart contract', function () {
 
       let transactions = [];
       transactions.push(new Transaction(12345678901, 'TXID1233', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(contractPayload)));
-      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": 0.001 }'));
+      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": "0.001" }'));
       transactions.push(new Transaction(30896501, 'TXID1234', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN.TEST", "precision": 3, "maxSupply": "1000", "isSignedWithActiveKey": true  }'));
 
       let block = {
@@ -539,7 +549,7 @@ describe('Tokens smart contract', function () {
 
       let transactions = [];
       transactions.push(new Transaction(12345678901, 'TXID1233', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(contractPayload)));
-      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": 0.001 }'));
+      transactions.push(new Transaction(30896501, 'TXID1236', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'updateParams', '{ "tokenCreationFee": "0.001" }'));
       transactions.push(new Transaction(30896501, 'TXID1234', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN.TEST", "precision": 3, "maxSupply": "1000", "isSignedWithActiveKey": true  }'));
 
       let block = {

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -150,7 +150,7 @@ describe.skip('witnesses', function () {
 
   before((done) => {
     new Promise(async (resolve) => {
-      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true });
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
       db = await client.db(conf.databaseName);
       await db.dropDatabase();
       resolve();


### PR DESCRIPTION
Note the difference in test cases, especially those with multiple actions with partial failure. In this case the entire transaction is rolled back.

Requires mongo to be run with replication. Simple step to change config file added to readme.