### PR TITLE
Fix cannot make NFT sell order with fee of 0

### DIFF
--- a/contracts/nftmarket.js
+++ b/contracts/nftmarket.js
@@ -610,7 +610,7 @@ actions.sell = async (payload) => {
     && api.assert(nfts && typeof nfts === 'object' && Array.isArray(nfts)
     && priceSymbol && typeof priceSymbol === 'string'
     && price && typeof price === 'string' && !api.BigNumber(price).isNaN()
-    && fee && typeof fee === 'number' && fee >= 0 && fee <= 10000 && Number.isInteger(fee), 'invalid params')
+    && typeof fee === 'number' && fee >= 0 && fee <= 10000 && Number.isInteger(fee), 'invalid params')
     && api.assert(nfts.length <= MAX_NUM_UNITS_OPERABLE, `cannot sell more than ${MAX_NUM_UNITS_OPERABLE} NFT instances at once`)
     && api.assert(tableExists, 'market not enabled for symbol')) {
     const nft = await api.db.findOneInTable('nft', 'nfts', { symbol });

--- a/test/nftmarket.js
+++ b/test/nftmarket.js
@@ -665,14 +665,16 @@ describe('nftmarket', function() {
       transactions.push(new Transaction(38145386, 'TXID1240', 'cryptomancer', 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "to":"aggroed", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}" }`));
       transactions.push(new Transaction(38145386, 'TXID1241', 'cryptomancer', 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "to":"aggroed", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}" }`));
       transactions.push(new Transaction(38145386, 'TXID1242', 'cryptomancer', 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "to":"marc", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}" }`));
-      transactions.push(new Transaction(38145386, 'TXID1243', 'cryptomancer', 'nftmarket', 'enableMarket', '{ "isSignedWithActiveKey": true, "symbol": "TEST" }'));
+      transactions.push(new Transaction(38145386, 'TXID1243', 'cryptomancer', 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "to":"marc", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}" }`));
+      transactions.push(new Transaction(38145386, 'TXID1244', 'cryptomancer', 'nftmarket', 'enableMarket', '{ "isSignedWithActiveKey": true, "symbol": "TEST" }'));
 
       // do a few sell orders
-      transactions.push(new Transaction(38145386, 'TXID1244', 'aggroed', 'nftmarket', 'sell', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "nfts": ["1","2","3"], "price": "3.14159", "priceSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "fee": 500 }`));
-      transactions.push(new Transaction(38145386, 'TXID1245', 'marc', 'nftmarket', 'sell', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "nfts": ["4"], "price": "8.000", "priceSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "fee": 500 }`));
+      transactions.push(new Transaction(38145386, 'TXID1245', 'aggroed', 'nftmarket', 'sell', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "nfts": ["1","2","3"], "price": "3.14159", "priceSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "fee": 500 }`));
+      transactions.push(new Transaction(38145386, 'TXID1246', 'marc', 'nftmarket', 'sell', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "nfts": ["4"], "price": "8.000", "priceSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "fee": 500 }`));
+      transactions.push(new Transaction(38145386, 'TXID1247', 'marc', 'nftmarket', 'sell', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "nfts": ["5"], "price": "8.000", "priceSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "fee": 0 }`));
 
       // now buy the orders
-      transactions.push(new Transaction(38145386, 'TXID1246', 'cryptomancer', 'nftmarket', 'buy', '{ "isSignedWithActiveKey": true, "marketAccount": "peakmonsters", "symbol": "TEST", "nfts": ["1","2","2","3","4","4"] }'));
+      transactions.push(new Transaction(38145386, 'TXID1248', 'cryptomancer', 'nftmarket', 'buy', '{ "isSignedWithActiveKey": true, "marketAccount": "peakmonsters", "symbol": "TEST", "nfts": ["1","2","2","3","4","4","5"] }'));
 
       let block = {
         refHiveBlockNumber: 38145386,
@@ -705,7 +707,7 @@ describe('nftmarket', function() {
         query: { account: 'cryptomancer' }
       });
 
-      assert.equal(instances.length, 4);
+      assert.equal(instances.length, 5);
 
       // check if orders have been removed
       let orders = await database1.find({
@@ -724,7 +726,7 @@ describe('nftmarket', function() {
       });
       
       assert.equal(balances[0].symbol, `${CONSTANTS.UTILITY_TOKEN_SYMBOL}`);
-      assert.equal(balances[0].balance, '176.37523000');
+      assert.equal(balances[0].balance, '168.07523000');
 
       // check that fees were sent to market account
       balances = await database1.find({
@@ -747,7 +749,7 @@ describe('nftmarket', function() {
       assert.equal(balances[0].balance, '8.95353150');
       assert.equal(balances[0].account, 'aggroed');
       assert.equal(balances[1].symbol, `${CONSTANTS.UTILITY_TOKEN_SYMBOL}`);
-      assert.equal(balances[1].balance, '7.60000000');
+      assert.equal(balances[1].balance, '15.60000000');
       assert.equal(balances[1].account, 'marc');
 
       // check that trade history table was updated


### PR DESCRIPTION
``if fee`` evaluates to false when its a integer of 0.

I believe typeof should be sufficient to determine whether its a `number` or `undefined`, which I think was the original intent.