### PR TITLE
Add logging to table hash computation

### DIFF
--- a/libs/Database.js
+++ b/libs/Database.js
@@ -112,6 +112,8 @@ class Database {
 
       this.databaseHash = SHA256(this.databaseHash + contractInDb.tables[table].hash)
         .toString(enchex);
+      console.log('updated hash of ' + contract + ':' + table + ' to ' + contractInDb.tables[table].hash);
+      console.log('updated db hash to ' + this.databaseHash);
     }
   }
 


### PR DESCRIPTION
This is to be able to debug all hash computation changes for a node to be able to cross check with other nodes.