### PR TITLE
Fix witness round hash, change reward amount to match inflation contract

### DIFF
--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -8,8 +8,8 @@ const NB_WITNESSES = NB_TOP_WITNESSES + NB_BACKUP_WITNESSES;
 const NB_WITNESSES_SIGNATURES_REQUIRED = 3;
 const MAX_ROUNDS_MISSED_IN_A_ROW = 3; // after that the witness is disabled
 const MAX_ROUND_PROPOSITION_WAITING_PERIOD = 40; // 20 blocks
-const NB_TOKENS_TO_REWARD = '0.01902587';
-const NB_TOKENS_NEEDED_BEFORE_REWARDING = '0.09512935';
+const NB_TOKENS_TO_REWARD = '0.00951293'; // inflation.js tokens per block
+const NB_TOKENS_NEEDED_BEFORE_REWARDING = '0.04756465'; // 5x to reward
 // eslint-disable-next-line no-template-curly-in-string
 const UTILITY_TOKEN_SYMBOL = "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'";
 // eslint-disable-next-line no-template-curly-in-string

--- a/plugins/P2P.js
+++ b/plugins/P2P.js
@@ -374,7 +374,17 @@ const proposeRoundHandler = async (args, callback) => {
           lastBlockRound = params.lastBlockRound;
 
           const startblockNum = params.lastVerifiedBlockNumber + 1;
-          const calculatedRoundHash = await calculateRoundHash(startblockNum, lastBlockRound);
+          let calculatedRoundHash = null;
+          let attempt = 1;
+          while (!calculatedRoundHash && attempt <= 3) {
+            if (attempt > 1) {
+                console.log("null round hash, waiting for block");
+                await new Promise(r => setTimeout(r, 3000));
+            }
+            calculatedRoundHash = await calculateRoundHash(startblockNum, lastBlockRound);
+            attempt += 1;
+          }
+          if (!calculatedRoundHash) console.error('null while verifying round hash proposal');
 
           if (calculatedRoundHash === roundHash) {
             if (round > lastVerifiedRoundNumber) {

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -1291,7 +1291,7 @@ describe('witnesses', function () {
         assert.equal(blockFromNode.roundHash, calculatedRoundHash);
         assert.equal(blockFromNode.signingKey, wif.createPublic().toString());
         assert.equal(blockFromNode.roundSignature, signatures[signatures.length - 1][1]);
-        await tableAsserts.assertUserBalances({ account: blockFromNode.witness, symbol: CONSTANTS.UTILITY_TOKEN_SYMBOL, balance: "0.01902587", stake: 0});
+        await tableAsserts.assertUserBalances({ account: blockFromNode.witness, symbol: CONSTANTS.UTILITY_TOKEN_SYMBOL, balance: "0.00951293", stake: 0});
         
         blockNum += 1;
         i +=1;


### PR DESCRIPTION
Missed rounds were happening because some round computations were done before the block was ready. Added a delay / retry mechanism to accomodate that.

Fix witness reward amount to match inflation.