### PR TITLE
Add block lookahead behavior to fetch blocks far in advance to speed up replay

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,9 +9,7 @@
     "streamNodes": [
         "https://api.deathwing.me",
         "https://rpc.ecency.com",
-        "https://hived.privex.io",
         "https://hived.emre.sh",
-        "https://anyx.io",
         "https://api.hive.blog"
     ],
     "startHiveBlock": 41967000,

--- a/config.json
+++ b/config.json
@@ -10,7 +10,9 @@
         "https://api.deathwing.me",
         "https://rpc.ecency.com",
         "https://hived.emre.sh",
-        "https://api.hive.blog"
+        "https://rpc.ausbit.dev",
+        "https://api.hive.blog",
+        "https://api.openhive.network"
     ],
     "startHiveBlock": 41967000,
     "genesisHiveBlock": 41967000,

--- a/config.json
+++ b/config.json
@@ -7,10 +7,12 @@
     "blocksLogFilePath": "./blocks.log",
     "javascriptVMTimeout": 10000,
     "streamNodes": [
-        "https://api.openhive.network",
-        "https://api.hive.blog",
+        "https://api.deathwing.me",
+        "https://rpc.ecency.com",
+        "https://hived.privex.io",
+        "https://hived.emre.sh",
         "https://anyx.io",
-        "https://api.hivekings.com"
+        "https://api.hive.blog"
     ],
     "startHiveBlock": 41967000,
     "genesisHiveBlock": 41967000,

--- a/plugins/Streamer.js
+++ b/plugins/Streamer.js
@@ -30,6 +30,15 @@ let blockStreamerHandler = null;
 let updaterGlobalPropsHandler = null;
 let lastBlockSentToBlockchain = 0;
 
+// For block prefetch mechanism
+const maxQps = 3;
+let capacity = 0;
+let totalInFlightRequests = 0;
+const inFlightRequests = {};
+const pendingRequests = [];
+const totalRequests = {};
+const totalTime = {};
+
 const getCurrentBlock = () => currentHiveBlock;
 
 const stop = () => {
@@ -278,7 +287,7 @@ const updateGlobalProps = async () => {
       // eslint-disable-next-line no-console
       console.log(`head_block_number ${hiveHeadBlockNumber}`, `currentBlock ${currentHiveBlock}`, `Hive blockchain is ${delta > 0 ? delta : 0} blocks ahead`);
       const nodes = Object.keys(totalRequests);
-      nodes.forEach(node => {
+      nodes.forEach((node) => {
         // eslint-disable-next-line no-console
         console.log(`Node block fetch average for ${node} is ${totalTime[node] / totalRequests[node]} with ${totalRequests[node]} requests`);
       });
@@ -304,14 +313,6 @@ const addBlockToBuffer = async (block) => {
   }
   buffer.push(finalBlock);
 };
-
-const maxQps = 3;
-let capacity = 0;
-let totalInFlightRequests = 0;
-const inFlightRequests = {};
-const pendingRequests = [];
-const totalRequests = {};
-const totalTime = {};
 
 const throttledGetBlockFromNode = async (blockNumber, node) => {
   if (inFlightRequests[node] < maxQps) {

--- a/plugins/Streamer.js
+++ b/plugins/Streamer.js
@@ -275,7 +275,7 @@ const updateGlobalProps = async () => {
       const globProps = await client.database.getDynamicGlobalProperties();
       hiveHeadBlockNumber = globProps.head_block_number;
       const delta = hiveHeadBlockNumber - currentHiveBlock;
-      // eslint-disable-next-line
+      // eslint-disable-next-line no-console
       console.log(`head_block_number ${hiveHeadBlockNumber}`, `currentBlock ${currentHiveBlock}`, `Hive blockchain is ${delta > 0 ? delta : 0} blocks ahead`);
     }
   } catch (ex) {
@@ -312,7 +312,6 @@ const throttledGetBlockFromNode = async (blockNumber, node) => {
   if (inFlightRequests[node] < maxQps) {
     totalInFlightRequests += 1;
     inFlightRequests[node] += 1;
-    // console.log('actually calling ' + blockNumber);
     let res = null;
     const timeStart = Date.now();
     try {
@@ -320,15 +319,16 @@ const throttledGetBlockFromNode = async (blockNumber, node) => {
       totalRequests[node] += 1;
       totalTime[node] += Date.now() - timeStart;
       if (totalRequests[node] % 100 === 0) {
+        // eslint-disable-next-line no-console
         console.log(`Node block fetch average for ${node} is ${totalTime[node] / totalRequests[node]}`);
       }
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error(`Error fetching block ${blockNumber} on node ${node}`);
+      // eslint-disable-next-line no-console
       console.error(err);
     }
-    
-    //console.timeEnd(`${node}_${blockNumber}`);
-    // console.log('done ' + blockNumber);
+
     inFlightRequests[node] -= 1;
     totalInFlightRequests -= 1;
     if (pendingRequests.length > 0) {
@@ -373,7 +373,6 @@ const getBlock = async (blockNumber) => {
   let scanIndex = lookaheadStartIndex;
   for (let i = 0; i < lookaheadBufferSize; i += 1) {
     if (!blockLookaheadBuffer[scanIndex]) {
-      // console.log(`fetch block ${lookaheadStartBlock + i} to put in ${scanIndex}`);
       blockLookaheadBuffer[scanIndex] = throttledGetBlock(lookaheadStartBlock + i);
     }
     scanIndex += 1;
@@ -384,15 +383,12 @@ const getBlock = async (blockNumber) => {
   if (lookupIndex >= 0 && lookupIndex < lookaheadBufferSize) {
     const block = await blockLookaheadBuffer[lookupIndex];
     if (block) {
-      // console.log(`got block ${blockNumber} from lookahead index ${lookupIndex}`);
       return block;
     }
     // retry
-    // console.log(`block ${blockNumber} not found, retry`);
     blockLookaheadBuffer[lookupIndex] = null;
     return null;
   }
-  // console.log(`block ${blockNumber} not in lookahead range (${lookaheadStartBlock},${lookaheadStartBlock + 99}`);
   return client.database.getBlock(blockNumber);
 };
 

--- a/plugins/Streamer.js
+++ b/plugins/Streamer.js
@@ -346,7 +346,7 @@ const throttledGetBlock = async (blockNumber) => {
       inFlightRequests[n] = 0;
       totalRequests[n] = 0;
       totalTime[n] = 0;
-      capacity += 4;
+      capacity += maxQps;
     }
   });
   if (totalInFlightRequests < capacity) {

--- a/plugins/Streamer.js
+++ b/plugins/Streamer.js
@@ -277,6 +277,11 @@ const updateGlobalProps = async () => {
       const delta = hiveHeadBlockNumber - currentHiveBlock;
       // eslint-disable-next-line no-console
       console.log(`head_block_number ${hiveHeadBlockNumber}`, `currentBlock ${currentHiveBlock}`, `Hive blockchain is ${delta > 0 ? delta : 0} blocks ahead`);
+      const nodes = Object.keys(totalRequests);
+      nodes.forEach(node => {
+        // eslint-disable-next-line no-console
+        console.log(`Node block fetch average for ${node} is ${totalTime[node] / totalRequests[node]} with ${totalRequests[node]} requests`);
+      });
     }
   } catch (ex) {
     console.error('An error occured while trying to fetch the Hive blockchain global properties'); // eslint-disable-line no-console
@@ -318,10 +323,6 @@ const throttledGetBlockFromNode = async (blockNumber, node) => {
       res = await clients[node].database.getBlock(blockNumber);
       totalRequests[node] += 1;
       totalTime[node] += Date.now() - timeStart;
-      if (totalRequests[node] % 100 === 0) {
-        // eslint-disable-next-line no-console
-        console.log(`Node block fetch average for ${node} is ${totalTime[node] / totalRequests[node]}`);
-      }
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error(`Error fetching block ${blockNumber} on node ${node}`);

--- a/plugins/Streamer.js
+++ b/plugins/Streamer.js
@@ -31,7 +31,7 @@ let updaterGlobalPropsHandler = null;
 let lastBlockSentToBlockchain = 0;
 
 // For block prefetch mechanism
-const maxQps = 3;
+const maxQps = 1;
 let capacity = 0;
 let totalInFlightRequests = 0;
 const inFlightRequests = {};

--- a/plugins/Streamer.js
+++ b/plugins/Streamer.js
@@ -299,10 +299,44 @@ const addBlockToBuffer = async (block) => {
   buffer.push(finalBlock);
 };
 
+// start at index 1, and rotate.
+const lookaheadBufferSize = 20;
+let lookaheadStartIndex = 0;
+let lookaheadStartBlock = currentHiveBlock;
+const blockLookaheadBuffer = Array(lookaheadBufferSize);
+const getBlock = async (blockNumber) => {
+  // schedule lookahead block fetch
+  let scanIndex = lookaheadStartIndex;
+  for (let i = 0; i < lookaheadBufferSize; i += 1) {
+    if (!blockLookaheadBuffer[scanIndex]) {
+      //console.log(`fetch block ${lookaheadStartBlock + i} to put in ${scanIndex}`);
+      blockLookaheadBuffer[scanIndex] = client.database.getBlock(lookaheadStartBlock + i);
+    }
+    scanIndex += 1;
+    if (scanIndex >= lookaheadBufferSize) scanIndex -= lookaheadBufferSize;
+  }
+  let lookupIndex = blockNumber - lookaheadStartBlock + lookaheadStartIndex;
+  if (lookupIndex >= lookaheadBufferSize) lookupIndex -= lookaheadBufferSize;
+  if (lookupIndex >= 0 && lookupIndex < lookaheadBufferSize) {
+    const block = await blockLookaheadBuffer[lookupIndex];
+    if (block) {
+      //console.log(`got block ${blockNumber} from lookahead index ${lookupIndex}`);
+      return block;
+    } else {
+      // retry
+      //console.log(`block ${blockNumber} not found, retry`);
+      blockLookaheadBuffer[lookupIndex] = null;
+      return null;
+    }
+  }
+  //console.log(`block ${blockNumber} not in lookahead range (${lookaheadStartBlock},${lookaheadStartBlock + 99}`);
+  return client.database.getBlock(blockNumber);
+};
+
 const streamBlocks = async (reject) => {
   if (stopStream) return;
   try {
-    const block = await client.database.getBlock(currentHiveBlock);
+    const block = await getBlock(currentHiveBlock);
     let addBlockToBuf = false;
 
     if (block) {
@@ -319,7 +353,7 @@ const streamBlocks = async (reject) => {
         }
       } else {
         // get the previous block
-        const prevBlock = await client.database.getBlock(currentHiveBlock - 1);
+        const prevBlock = await getBlock(currentHiveBlock - 1);
 
         if (prevBlock && prevBlock.block_id === block.previous) {
           addBlockToBuf = true;
@@ -333,6 +367,10 @@ const streamBlocks = async (reject) => {
         await addBlockToBuffer(block);
       }
       currentHiveBlock += 1;
+      blockLookaheadBuffer[lookaheadStartIndex] = null;
+      lookaheadStartIndex += 1;
+      if (lookaheadStartIndex >= lookaheadBufferSize) lookaheadStartIndex -= lookaheadBufferSize;
+      lookaheadStartBlock += 1;
       streamBlocks(reject);
     } else {
       blockStreamerHandler = setTimeout(() => {
@@ -355,6 +393,8 @@ const startStreaming = (conf) => {
     startHiveBlock,
   } = conf;
   currentHiveBlock = startHiveBlock;
+  lookaheadStartIndex = 0;
+  lookaheadStartBlock = currentHiveBlock;
   chainIdentifier = chainId;
   const node = streamNodes[0];
   initHiveClient(node);


### PR DESCRIPTION
Among all listed nodes, it will send 3 QPS (configurable) at a time to each node to fetch blocks, and allows for utilizing faster nodes more efficiently (as they free up their requests more quickly). But broken nodes will slow down the whole process, so this will need some monitoring (todo-- automatically kick out repeatedly failing nodes)