### PR TITLE
small random weight selection fix to witness contract, witness contract cleanup

### DIFF
--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -540,13 +540,12 @@ const manageWitnessesSchedule = async () => {
           // calculate a random weight if not done yet
           if (schedule.length >= NB_TOP_WITNESSES
             && randomWeight === null) {
-            const min = api.BigNumber(accWeight)
-              .plus(GOVERNANCE_TOKEN_MIN_VALUE);
-
-            randomWeight = api.BigNumber(totalApprovalWeight)
-              .minus(min)
-              .times(random)
-              .plus(min)
+            randomWeight = api.BigNumber(accWeight)
+              .plus(GOVERNANCE_TOKEN_MIN_VALUE)
+              .plus(api.BigNumber(totalApprovalWeight)
+                .minus(accWeight)
+                .times(random)
+                .toFixed(GOVERNANCE_TOKEN_PRECISION, 1))
               .toFixed(GOVERNANCE_TOKEN_PRECISION);
           }
 

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -344,7 +344,7 @@ const changeCurrentWitness = async () => {
   const random = api.random();
   const randomWeight = api.BigNumber(totalApprovalWeight)
     .times(random)
-    .toFixed(GOVERNANCE_TOKEN_PRECISION);
+    .toFixed(GOVERNANCE_TOKEN_PRECISION, 1);
 
   let offset = 0;
   let accWeight = 0;

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -41,29 +41,6 @@ actions.createSSC = async () => {
     };
 
     await api.db.insert('params', params);
-  } else {
-    // TODO: cleanup when launching for mainnet / next update
-    const witnesses = await api.db.find('witnesses', { });
-
-    for (let index = 0; index < witnesses.length; index += 1) {
-      const witness = witnesses[index];
-      witness.missedRounds = 0;
-      witness.missedRoundsInARow = 0;
-      await api.db.update('witnesses', witness);
-    }
-
-    const schedules = await api.db.find('schedules', { });
-
-    for (let index = 0; index < schedules.length; index += 1) {
-      const schedule = schedules[index];
-      await api.db.remove('schedules', schedule);
-    }
-
-    const params = await api.db.findOne('params', {});
-    params.currentWitness = null;
-    params.blockNumberWitnessChange = 0;
-    params.lastWitnesses = [];
-    await api.db.update('params', params);
   }
 };
 
@@ -81,14 +58,6 @@ actions.resetSchedule = async () => {
   params.currentWitness = null;
   params.blockNumberWitnessChange = 0;
   params.lastWitnesses = [];
-  await api.db.update('params', params);
-};
-
-actions.setTestHpg = async () => {
-  if (api.sender !== api.owner) return;
-
-  const params = await api.db.findOne('params', {});
-  params.currentWitness = 'test.hpg';
   await api.db.update('params', params);
 };
 


### PR DESCRIPTION
fix random selection of witnesses, it is off by lowest precision amount. See https://stackoverflow.com/questions/1527803/generating-random-whole-numbers-in-javascript-in-a-specific-range for formula

This is a difference between the two following formulas:

floor( rnd * ( TOTAL - ACC )) + ACC + eps

vs

floor( rnd * (TOTAL  - ACC - eps) + ACC + eps )

where (eps  = smallest positive token amount, ACC is top witnesses approval weight sum,  TOTAL is total witnesses approval weight sum)

Also changes rounding modes to use floor instead of round as per https://mikemcl.github.io/bignumber.js/#toFix

We should probably audit other usages of random and fix accordingly. It's a very minimal impact in general though. 