### PR TITLE
fix start block detection and skip block detection

### DIFF
--- a/plugins/Blockchain.js
+++ b/plugins/Blockchain.js
@@ -42,6 +42,13 @@ function addBlock(block) {
   return database.addBlock(block);
 }
 
+function getRefBlockNumber(block) {
+  if (block.otherHashChangeRefHiveBlocks) {
+    return block.otherHashChangeRefHiveBlocks[block.otherHashChangeRefHiveBlocks.length - 1];
+  }
+  return block.refHiveBlockNumber;
+}
+
 // produce all the pending transactions, that will result in the creation of a block
 async function producePendingTransactions(
   refHiveBlockNumber, refHiveBlockId, prevRefHiveBlockId, transactions, timestamp,
@@ -49,7 +56,8 @@ async function producePendingTransactions(
   const previousBlock = await getLatestBlockMetadata();
   if (previousBlock) {
     // skip block if it has been parsed already
-    if (refHiveBlockNumber <= previousBlock.refHiveBlockNumber) {
+    const lastRefBlockNumber = getRefBlockNumber(previousBlock);
+    if (refHiveBlockNumber <= lastRefBlockNumber) {
       // eslint-disable-next-line no-console
       console.warn(`skipping Hive block ${refHiveBlockNumber} as it has already been parsed`);
       return;

--- a/plugins/Streamer.js
+++ b/plugins/Streamer.js
@@ -478,6 +478,13 @@ const startStreaming = (conf) => {
   });
 };
 
+function getRefBlockNumber(block) {
+  if (block.otherHashChangeRefHiveBlocks) {
+    return block.otherHashChangeRefHiveBlocks[block.otherHashChangeRefHiveBlocks.length - 1];
+  }
+  return block.refHiveBlockNumber;
+}
+
 // stream the Hive blockchain to find transactions related to the sidechain
 const init = async (conf) => {
   const {
@@ -491,9 +498,10 @@ const init = async (conf) => {
   // get latest block metadata to ensure that startHiveBlock saved in the config.json is not lower
   const block = await getLatestBlockMetadata();
   if (block) {
-    if (finalConf.startHiveBlock < block.refHiveBlockNumber) {
-      console.log('adjusted startHiveBlock automatically as it was lower than the refHiveBlockNumber available'); // eslint-disable-line no-console
-      finalConf.startHiveBlock = block.refHiveBlockNumber + 1;
+    const refBlockNumber = getRefBlockNumber(block);
+    if (finalConf.startHiveBlock < refBlockNumber) {
+      console.log(`adjusted startHiveBlock automatically to block ${refBlockNumber + 1} as it was lower than the refHiveBlockNumber available`); // eslint-disable-line no-console
+      finalConf.startHiveBlock = refBlockNumber + 1;
     }
   }
 


### PR DESCRIPTION
Now it will take into account the additionalHashChangeBlocks, which is the scenario where for some reason or other the node is processing a hive block that changes the DB *without* producing any logs / additional block (e.g. with the automated actions). This can happen right now because of comment actions that get sent to the Blockchain plugin but get ignored due contract not being implemented and then subsequently getting filtered out.

Note that this is actually not so much of a risk because most such actions modifying the DB are idempotent (they will only happen once based on a timestamp condition, so re-running the same action again will not produce additional differences). However, this may not always be the case, so we should be proactive about preventing a state where a node restart would apply double-actions inadvertently.