### PR TITLE
Clean up post vote data after payout

### DIFF
--- a/contracts/comments.js
+++ b/contracts/comments.js
@@ -26,6 +26,7 @@ actions.createSSC = async () => {
       maintenanceTokensPerAction: 1,
       maintenanceTokenOffset: 0,
       maxPostsProcessedPerRound: 1000,
+      voteQueryLimit: 1000,
     };
     await api.db.insert('params', params);
   }
@@ -39,6 +40,7 @@ actions.updateParams = async (payload) => {
     updateFee,
     maintenanceTokensPerAction,
     maxPostsProcessedPerRound,
+    voteQueryLimit,
   } = payload;
 
   const params = await api.db.findOne('params', {});
@@ -58,6 +60,10 @@ actions.updateParams = async (payload) => {
   if (maxPostsProcessedPerRound) {
     if (!api.assert(Number.isInteger(maxPostsProcessedPerRound) && maxPostsProcessedPerRound >= 1, 'invalid maxPostsProcessedPerRound')) return;
     params.maxPostsProcessedPerRound = maxPostsProcessedPerRound;
+  }
+  if (voteQueryLimit) {
+    if (!api.assert(Number.isInteger(voteQueryLimit) && voteQueryLimit >= 1, 'invalid voteQueryLimit')) return;
+    params.voteQueryLimit = voteQueryLimit;
   }
 
   await api.db.update('params', params);
@@ -141,14 +147,17 @@ async function payOutBeneficiaries(rewardPool, token, post, authorBenePortion) {
   return totalBenePay;
 }
 
-async function payOutCurators(rewardPool, token, post, curatorPortion) {
+async function payOutCurators(rewardPool, token, post, curatorPortion, params) {
   const {
     authorperm,
     symbol,
     rewardPoolId,
   } = post;
+  const {
+      voteQueryLimit,
+  } = params;
   let offset = 0;
-  let votesToPayout = await api.db.find('votes', { authorperm, symbol, rewardPoolId }, 1000, offset, [{ index: 'byTimestamp', descending: false }]);
+  let votesToPayout = await api.db.find('votes', { authorperm, symbol, rewardPoolId }, voteQueryLimit, 0, [{ index: 'byTimestamp', descending: false }]);
   while (votesToPayout.length > 0) {
     for (let i = 0; i < votesToPayout.length; i += 1) {
       const vote = votesToPayout[i];
@@ -164,22 +173,18 @@ async function payOutCurators(rewardPool, token, post, curatorPortion) {
         });
         await payUser(symbol, votePay, vote.voter, rewardPool.config.stakedRewardPercentage);
       }
+      await api.db.remove('votes', vote);
     }
-    if (votesToPayout.length < 1000) {
+    if (votesToPayout.length < voteQueryLimit) {
       break;
     }
-    offset += 1000;
-    votesToPayout = await api.db.find('votes', { authorperm, symbol }, 1000, offset, [{ index: 'byTimestamp', descending: false }]);
+    votesToPayout = await api.db.find('votes', { authorperm, symbol }, voteQueryLimit, 0, [{ index: 'byTimestamp', descending: false }]);
   }
 }
 
-async function payOutPost(rewardPool, token, post, timestamp) {
+async function payOutPost(rewardPool, token, post, timestamp, params) {
   if (post.declinePayout) {
-    // eslint-disable-next-line no-param-reassign
-    post.lastPayout = timestamp;
-    // eslint-disable-next-line no-param-reassign
-    post.totalPayoutValue = api.BigNumber(0);
-    await api.db.update('posts', post);
+    await api.db.remove('posts', post);
     return;
   }
   const postClaims = calculateWeightRshares(rewardPool, post.voteRshareSum);
@@ -195,20 +200,13 @@ async function payOutPost(rewardPool, token, post, timestamp) {
   const authorBenePortion = api.BigNumber(postPendingToken).minus(curatorPortion)
     .toFixed(token.precision, api.BigNumber.ROUND_DOWN);
 
-  // eslint-disable-next-line no-param-reassign
-  post.beneficiariesPayoutValue = await payOutBeneficiaries(
-    rewardPool, token, post, authorBenePortion,
+  const beneficiariesPayoutValue = await payOutBeneficiaries(
+      rewardPool, token, post, authorBenePortion,
   );
-  const authorPortion = api.BigNumber(authorBenePortion).minus(post.beneficiariesPayoutValue)
+  const authorPortion = api.BigNumber(authorBenePortion).minus(beneficiariesPayoutValue)
     .toFixed(token.precision, api.BigNumber.ROUND_DOWN);
-  // eslint-disable-next-line no-param-reassign
-  post.lastPayout = timestamp;
-  // eslint-disable-next-line no-param-reassign
-  post.totalPayoutValue = postPendingToken;
-  // eslint-disable-next-line no-param-reassign
-  post.curatorPayoutValue = curatorPortion;
 
-  await payOutCurators(rewardPool, token, post, curatorPortion);
+  await payOutCurators(rewardPool, token, post, curatorPortion, params);
   api.emit('authorReward', {
     rewardPoolId: post.rewardPoolId,
     authorperm: post.authorperm,
@@ -217,7 +215,8 @@ async function payOutPost(rewardPool, token, post, timestamp) {
     quantity: authorPortion,
   });
   await payUser(post.symbol, authorPortion, post.author, rewardPool.config.stakedRewardPercentage);
-  await api.db.update('posts', post);
+  await api.db.remove('posts', post);
+  return postPendingToken;
 }
 
 async function computePostRewards(params, rewardPool, token) {
@@ -272,8 +271,8 @@ async function computePostRewards(params, rewardPool, token) {
     let lastPostCashout = lastPostRewardTimestamp;
     for (let i = 0; i < postsToPayout.length; i += 1) {
       const post = postsToPayout[i];
-      await payOutPost(rewardPool, token, post, timestamp);
-      deductFromRewardPool = deductFromRewardPool.plus(post.totalPayoutValue);
+      const totalPayoutValue = await payOutPost(rewardPool, token, post, timestamp, params);
+      deductFromRewardPool = deductFromRewardPool.plus(totalPayoutValue);
       lastPostCashout = post.cashoutTime;
     }
     // eslint-disable-next-line no-param-reassign

--- a/test/comments.js
+++ b/test/comments.js
@@ -1967,7 +1967,7 @@ describe('comments', function () {
       res = await fixture.database.getLatestBlockInfo();
       await tableAsserts.assertNoErrorInLastBlock();
 
-      assert.equal(JSON.parse(res.transactions[0].logs).events.find(ev => ev.event === 'authorReward' && ev.data.authorperm === '@author1/test1'), undefined);
+      assert.equal(JSON.stringify(JSON.parse(res.transactions[0].logs).events.find(ev => ev.event === 'authorReward' && ev.data.authorperm === '@author1/test1')), '{"contract":"comments","event":"authorReward","data":{"rewardPoolId":1,"authorperm":"@author1/test1","symbol":"TKN","account":"author1","quantity":"0"}}');
       assert.equal(JSON.parse(res.transactions[0].logs).events.find(ev => ev.event === 'beneficiaryReward' && ev.data.authorperm === '@author1/test1' && ev.data.account === 'bene1'), undefined);
       assert.equal(JSON.parse(res.transactions[0].logs).events.find(ev => ev.event === 'beneficiaryReward' && ev.data.authorperm === '@author1/test1' && ev.data.account === 'bene2'), undefined);
       assert.equal(JSON.parse(res.transactions[0].logs).events.find(ev => ev.event === 'curationReward' && ev.data.authorperm === '@author1/test1' && ev.data.account === 'voter1'), undefined);
@@ -1979,6 +1979,9 @@ describe('comments', function () {
 
       post = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test1" }});
       assert.equal(post, null);
+
+      let rewardPool = await fixture.database.findOne({ contract: 'comments', table: 'rewardPools', query: { _id: 1}});
+      assert.equal(JSON.stringify(rewardPool), '{"_id":1,"symbol":"TKN","rewardPool":"345600.00000000","lastRewardTimestamp":1528502400000,"lastPostRewardTimestamp":1528416000000,"lastClaimDecayTimestamp":1528502400000,"createdTimestamp":1527811200000,"config":{"postRewardCurve":"power","postRewardCurveParameter":"1","curationRewardCurve":"power","curationRewardCurveParameter":"1","curationRewardPercentage":50,"cashoutWindowDays":7,"rewardPerInterval":"1.5","rewardIntervalSeconds":3,"voteRegenerationDays":14,"downvoteRegenerationDays":14,"stakedRewardPercentage":50,"votePowerConsumption":200,"downvotePowerConsumption":2000,"tags":["scottest"]},"pendingClaims":"14.6666666666","active":true}');
 
       resolve();
     })

--- a/test/comments.js
+++ b/test/comments.js
@@ -809,9 +809,9 @@ describe('comments', function () {
       await tableAsserts.assertUserBalances({account: "voter2", symbol: "TKN", balance: "9386.68589166", stake: "9396.68589165"});
 
       post = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test1" }});
-      assert.equal(JSON.stringify(post), '{"_id":{"authorperm":"@author1/test1","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test1","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"10.0000000000","voteRshareSum":"10.0000000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"40878.98223120","lastPayout":1528502400000,"totalPayoutValue":"81757.96446241"}');
+      assert.equal(post, null);
       post2 = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test2" }});
-      assert.equal(JSON.stringify(post2), '{"_id":{"authorperm":"@author1/test2","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test2","author":"author1","created":1527897600000,"cashoutTime":1528502400000,"votePositiveRshareSum":"17.8000000000","voteRshareSum":"17.8000000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"72764.58837155","lastPayout":1528502400000,"totalPayoutValue":"145529.17674310"}');
+      assert.equal(post2, null);
 
       rewardPool = await fixture.database.findOne({ contract: 'comments', table: 'rewardPools', query: { _id: 1}});
       assert.equal(JSON.stringify(rewardPool), '{"_id":1,"symbol":"TKN","rewardPool":"118312.85879449","lastRewardTimestamp":1528502400000,"lastPostRewardTimestamp":1528502400000,"lastClaimDecayTimestamp":1528502400000,"createdTimestamp":1527811200000,"config":{"postRewardCurve":"power","postRewardCurveParameter":"1","curationRewardCurve":"power","curationRewardCurveParameter":"0.5","curationRewardPercentage":50,"cashoutWindowDays":7,"rewardPerInterval":"1.5","rewardIntervalSeconds":3,"voteRegenerationDays":14,"downvoteRegenerationDays":14,"stakedRewardPercentage":50,"votePowerConsumption":200,"downvotePowerConsumption":2000,"tags":["scottest"]},"pendingClaims":"42.2711111110","active":true}');
@@ -930,9 +930,9 @@ describe('comments', function () {
       await tableAsserts.assertUserBalances({account: "voter2", symbol: "TKN", balance: "12500.04354009", stake: "12510.04354009"});
 
       post = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test1" }});
-      assert.equal(JSON.stringify(post), '{"_id":{"authorperm":"@author1/test1","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test1","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"10.0000000000","voteRshareSum":"10.0000000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"40423.55904513","lastPayout":1528502400000,"totalPayoutValue":"80847.11809027"}');
+      assert.equal(post, null);
       post2 = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test2" }});
-      assert.equal(JSON.stringify(post2), '{"_id":{"authorperm":"@author1/test2","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test2","author":"author1","created":1527897600000,"cashoutTime":1528502400000,"votePositiveRshareSum":"17.8000000000","voteRshareSum":"17.8000000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"73209.45101979","lastPayout":1528502400000,"totalPayoutValue":"146418.90203958"}');
+      assert.equal(post2, null);
 
       rewardPool = await fixture.database.findOne({ contract: 'comments', table: 'rewardPools', query: { _id: 1}});
       assert.equal(JSON.stringify(rewardPool), '{"_id":1,"symbol":"TKN","rewardPool":"118333.97987015","lastRewardTimestamp":1528502400000,"lastPostRewardTimestamp":1528502400000,"lastClaimDecayTimestamp":1528502400000,"createdTimestamp":1527811200000,"config":{"postRewardCurve":"power","postRewardCurveParameter":"1.03","curationRewardCurve":"power","curationRewardCurveParameter":"0.7","curationRewardPercentage":50,"cashoutWindowDays":7,"rewardPerInterval":"1.5","rewardIntervalSeconds":3,"voteRegenerationDays":14,"downvoteRegenerationDays":14,"stakedRewardPercentage":50,"votePowerConsumption":200,"downvotePowerConsumption":2000,"tags":["scottest"]},"pendingClaims":"45.8046100634","active":true}');
@@ -1108,7 +1108,7 @@ describe('comments', function () {
       await tableAsserts.assertUserBalances({account: "voter1", symbol: "TKN", balance: "0", stake: "10.00000000"});
 
       post = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test1" }});
-      assert.equal(JSON.stringify(post), '{"_id":{"authorperm":"@author1/test1","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test1","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"10.0000000000","voteRshareSum":"0.9800000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"22121.65080058","lastPayout":1528416000000,"totalPayoutValue":"44243.30160116"}');
+      assert.equal(post, null);
 
       rewardPool = await fixture.database.findOne({ contract: 'comments', table: 'rewardPools', query: { _id: 1}});
       assert.equal(JSON.stringify(rewardPool), '{"_id":1,"symbol":"TKN","rewardPool":"258156.69839884","lastRewardTimestamp":1528416000000,"lastPostRewardTimestamp":1528416000000,"lastClaimDecayTimestamp":1528416000000,"createdTimestamp":1527811200000,"config":{"postRewardCurve":"power","postRewardCurveParameter":"1.03","curationRewardCurve":"power","curationRewardCurveParameter":"0.5","curationRewardPercentage":50,"cashoutWindowDays":7,"rewardPerInterval":"1.5","rewardIntervalSeconds":3,"voteRegenerationDays":14,"downvoteRegenerationDays":14,"stakedRewardPercentage":50,"votePowerConsumption":200,"downvotePowerConsumption":2000,"tags":["scottest"]},"pendingClaims":"6.6941758481","active":true}');
@@ -1251,9 +1251,9 @@ describe('comments', function () {
       await tableAsserts.assertUserBalances({account: "voter2", symbol: "TKN", balance: "0", stake: "10.00000000"});
 
       post = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test1" }});
-      assert.equal(JSON.stringify(post), '{"_id":{"authorperm":"@author1/test1","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test1","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"1.0000000000","voteRshareSum":"0.0000000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"0.00000000","lastPayout":1528502400000,"totalPayoutValue":"0.00000000"}');
+      assert.equal(post, null);
       post2 = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test2" }});
-      assert.equal(JSON.stringify(post2), '{"_id":{"authorperm":"@author1/test2","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test2","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"1.9960000000","voteRshareSum":"-7.8040000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"0.00000000","lastPayout":1528502400000,"totalPayoutValue":"0.00000000"}');
+      assert.equal(post2, null);
 
       rewardPool = await fixture.database.findOne({ contract: 'comments', table: 'rewardPools', query: { _id: 1}});
       assert.equal(JSON.stringify(rewardPool), '{"_id":1,"symbol":"TKN","rewardPool":"345600.00000000","lastRewardTimestamp":1528502400000,"lastPostRewardTimestamp":1528416000000,"lastClaimDecayTimestamp":1528502400000,"createdTimestamp":1527811200000,"config":{"postRewardCurve":"power","postRewardCurveParameter":"1.03","curationRewardCurve":"power","curationRewardCurveParameter":"0.7","curationRewardPercentage":50,"cashoutWindowDays":7,"rewardPerInterval":"1.5","rewardIntervalSeconds":3,"voteRegenerationDays":14,"downvoteRegenerationDays":14,"stakedRewardPercentage":50,"votePowerConsumption":200,"downvotePowerConsumption":2000,"tags":["scottest"]},"pendingClaims":"1.5121581976","active":true}');
@@ -1571,7 +1571,7 @@ describe('comments', function () {
       });
   });
 
-  it('pays out maxPostsProcessedPerRound', (done) => {
+  it('pays out maxPostsProcessedPerRound and respects voteQueryLimit', (done) => {
     new Promise(async (resolve) => {
       await fixture.setUp();
 
@@ -1583,7 +1583,7 @@ describe('comments', function () {
 
       transactions = [];
       refBlockNumber = fixture.getNextRefBlockNumber();
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'comments', 'updateParams', '{ "maxPostsProcessedPerRound": 1 }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'comments', 'updateParams', '{ "maxPostsProcessedPerRound": 1, "voteQueryLimit": 1 }'));
 
       block = {
         refHiveBlockNumber: refBlockNumber,
@@ -1597,6 +1597,7 @@ describe('comments', function () {
       await tableAsserts.assertNoErrorInLastBlock();
       let params = await fixture.database.findOne({ contract: 'comments', table: 'params', query: {}});
       assert.equal(params.maxPostsProcessedPerRound, 1);
+      assert.equal(params.voteQueryLimit, 1);
 
       transactions = [];
       refBlockNumber = fixture.getNextRefBlockNumber();
@@ -1692,7 +1693,7 @@ describe('comments', function () {
       await tableAsserts.assertUserBalances({account: "voter2", symbol: "TKN", balance: "0", stake: "10.00000000"});
 
       post = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test1" }});
-      assert.equal(JSON.stringify(post), '{"_id":{"authorperm":"@author1/test1","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test1","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"10.0000000000","voteRshareSum":"10.0000000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"70139.09527085","lastPayout":1528502400000,"totalPayoutValue":"140278.19054171"}');
+      assert.equal(post, null);
       post2 = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test2" }});
       // not paid out yet
       assert.equal(JSON.stringify(post2), '{"_id":{"authorperm":"@author1/test2","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test2","author":"author1","created":1527897600000,"cashoutTime":1528502400000,"votePositiveRshareSum":"17.8000000000","voteRshareSum":"17.8000000000"}');
@@ -1729,10 +1730,8 @@ describe('comments', function () {
       await tableAsserts.assertUserBalances({account: "voter1", symbol: "TKN", balance: "49390.32216763", stake: "49400.32216761"});
       await tableAsserts.assertUserBalances({account: "voter2", symbol: "TKN", balance: "7426.37075256", stake: "7436.37075255"});
 
-      post = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test1" }});
-      assert.equal(JSON.stringify(post), '{"_id":{"authorperm":"@author1/test1","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test1","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"10.0000000000","voteRshareSum":"10.0000000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"70139.09527085","lastPayout":1528502400000,"totalPayoutValue":"140278.19054171"}');
       post2 = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test2" }});
-      assert.equal(JSON.stringify(post2), '{"_id":{"authorperm":"@author1/test2","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test2","author":"author1","created":1527897600000,"cashoutTime":1528502400000,"votePositiveRshareSum":"17.8000000000","voteRshareSum":"17.8000000000","beneficiariesPayoutValue":"0","curatorPayoutValue":"43494.29056951","lastPayout":1528502403000,"totalPayoutValue":"86988.58113902"}');
+      assert.equal(post2, null);
 
       rewardPool = await fixture.database.findOne({ contract: 'comments', table: 'rewardPools', query: { _id: 1}});
       assert.equal(JSON.stringify(rewardPool), '{"_id":1,"symbol":"TKN","rewardPool":"118334.72831927","lastRewardTimestamp":1528502403000,"lastPostRewardTimestamp":1528502400000,"lastClaimDecayTimestamp":1528502403000,"createdTimestamp":1527811200000,"config":{"postRewardCurve":"power","postRewardCurveParameter":"1.03","curationRewardCurve":"power","curationRewardCurveParameter":"0.7","curationRewardPercentage":50,"cashoutWindowDays":7,"rewardPerInterval":"1.5","rewardIntervalSeconds":3,"voteRegenerationDays":14,"downvoteRegenerationDays":14,"stakedRewardPercentage":50,"votePowerConsumption":200,"downvotePowerConsumption":2000,"tags":["scottest"]},"pendingClaims":"45.8045489551","active":true}');
@@ -1905,7 +1904,7 @@ describe('comments', function () {
       assert.equal(JSON.stringify(JSON.parse(res.transactions[0].logs).events.find(ev => ev.event === 'curationReward' && ev.data.authorperm === '@author1/test1' && ev.data.account === 'voter1')), '{"contract":"comments","event":"curationReward","data":{"rewardPoolId":1,"authorperm":"@author1/test1","symbol":"TKN","account":"voter1","quantity":"117818.18181871"}}');
 
       post = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test1" }});
-      assert.equal(JSON.stringify(post), '{"_id":{"authorperm":"@author1/test1","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test1","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"10.0000000000","voteRshareSum":"10.0000000000","beneficiaries":[{"account":"bene1","weight":5000},{"account":"bene2","weight":1}],"declinePayout":false,"beneficiariesPayoutValue":"58920.87272754","curatorPayoutValue":"117818.18181871","lastPayout":1528502400000,"totalPayoutValue":"235636.36363743"}');
+      assert.equal(post, null);
 
       await tableAsserts.assertUserBalances({account: "author1", symbol: "TKN", balance: "29448.65454559", stake: "29448.65454559"});
       await tableAsserts.assertUserBalances({account: "bene1", symbol: "TKN", balance: "29454.54545468", stake: "29454.54545468"});
@@ -1979,7 +1978,7 @@ describe('comments', function () {
       await tableAsserts.assertUserBalances({account: "voter1", symbol: "TKN", balance: "0", stake: "10.00000000"});
 
       post = await fixture.database.findOne({ contract: 'comments', table: 'posts', query: { rewardPoolId: 1, authorperm: "@author1/test1" }});
-      assert.equal(JSON.stringify(post), '{"_id":{"authorperm":"@author1/test1","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test1","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"10.0000000000","voteRshareSum":"10.0000000000","beneficiaries":[{"account":"bene1","weight":5000},{"account":"bene2","weight":1}],"declinePayout":true,"lastPayout":1528502400000,"totalPayoutValue":"0"}');
+      assert.equal(post, null);
 
       resolve();
     })


### PR DESCRIPTION
Cleans up post and vote data after payout, as it is no longer needed.

Emit event for declined post payout so indexers can pick up the change as well.