### PR TITLE
Add tick registration mechanism

### DIFF
--- a/contracts/testing/dummyTicks.js
+++ b/contracts/testing/dummyTicks.js
@@ -1,0 +1,27 @@
+actions.createSSC = function (payload) {
+  // Initialize the smart contract via the create action
+}
+actions.checkPendingUnstakes = () => {
+    api.emit('checkPendingUnstakes', {});
+}
+actions.checkPendingUndelegations = () => {
+    api.emit('checkPendingUndelegations', {});
+}
+actions.tick = () => {
+    api.emit('tick', {});
+}
+actions.checkPendingLotteries = () => {
+    api.emit('checkPendingLotteries', {});
+}
+actions.checkPendingAirdrops = () => {
+    api.emit('checkPendingAirdrops', {});
+}
+actions.updateAuctions = () => {
+    api.emit('updateAuctions', {});
+}
+actions.scheduleWitnesses = () => {
+    api.emit('scheduleWitnesses', {});
+}
+actions.checkPendingDtfs = () => {
+    api.emit('checkPendingDtfs', {});
+}

--- a/contracts/testing/dummyTicks.js
+++ b/contracts/testing/dummyTicks.js
@@ -1,27 +1,32 @@
-actions.createSSC = function (payload) {
+/* eslint-disable no-await-in-loop */
+/* eslint-disable quote-props */
+/* eslint-disable max-len */
+/* global actions, api */
+
+actions.createSSC = () => {
   // Initialize the smart contract via the create action
-}
+};
 actions.checkPendingUnstakes = () => {
-    api.emit('checkPendingUnstakes', {});
-}
+  api.emit('checkPendingUnstakes', {});
+};
 actions.checkPendingUndelegations = () => {
-    api.emit('checkPendingUndelegations', {});
-}
+  api.emit('checkPendingUndelegations', {});
+};
 actions.tick = () => {
-    api.emit('tick', {});
-}
+  api.emit('tick', {});
+};
 actions.checkPendingLotteries = () => {
-    api.emit('checkPendingLotteries', {});
-}
+  api.emit('checkPendingLotteries', {});
+};
 actions.checkPendingAirdrops = () => {
-    api.emit('checkPendingAirdrops', {});
-}
+  api.emit('checkPendingAirdrops', {});
+};
 actions.updateAuctions = () => {
-    api.emit('updateAuctions', {});
-}
+  api.emit('updateAuctions', {});
+};
 actions.scheduleWitnesses = () => {
-    api.emit('scheduleWitnesses', {});
-}
+  api.emit('scheduleWitnesses', {});
+};
 actions.checkPendingDtfs = () => {
-    api.emit('checkPendingDtfs', {});
-}
+  api.emit('checkPendingDtfs', {});
+};

--- a/libs/Block.js
+++ b/libs/Block.js
@@ -153,37 +153,22 @@ class Block {
       // the "unknown error" errors are removed as they are related to a non existing action
       if (transaction.logs !== '{}'
         && transaction.logs !== '{"errors":["unknown error"]}') {
-        if (transaction.contract === 'witnesses'
-          && transaction.action === 'scheduleWitnesses'
+        let tickingAction = false;
+        for (let j = 0; j < contractsConfig.contractTicks.length; j += 1) {
+          const contractTick = contractsConfig.contractTicks[j];
+          if (transaction.contract === contractTick.contract
+            && transaction.action === contractTick.action
           && transaction.logs === '{"errors":["contract doesn\'t exist"]}') {
-          // don't save logs
-        } else if (transaction.contract === 'inflation'
+            tickingAction = true;
+          }
+        }
+
+
+        if (transaction.contract === 'inflation'
           && transaction.action === 'issueNewTokens'
           && transaction.logs === '{"errors":["contract doesn\'t exist"]}') {
           // don't save logs
-        } else if (transaction.contract === 'nft'
-          && transaction.action === 'checkPendingUndelegations'
-          && transaction.logs === '{"errors":["contract doesn\'t exist"]}') {
-          // don't save logs
-        } else if (transaction.contract === 'botcontroller'
-          && transaction.action === 'tick'
-          && transaction.logs === '{"errors":["contract doesn\'t exist"]}') {
-          // don't save logs
-        } else if (transaction.contract === 'mining'
-          && transaction.action === 'checkPendingLotteries'
-          && transaction.logs === '{"errors":["contract doesn\'t exist"]}') {
-          // don't save logs
-        } else if (transaction.contract === 'airdrops'
-          && transaction.action === 'checkPendingAirdrops'
-          && transaction.logs === '{"errors":["contract doesn\'t exist"]}') {
-          // don't save logs
-        } else if (transaction.contract === 'nftauction'
-          && transaction.action === 'updateAuctions'
-          && transaction.logs === '{"errors":["contract doesn\'t exist"]}') {
-          // don't save logs
-        } else if (transaction.contract === 'tokenfunds'
-          && transaction.action === 'checkPendingDtfs'
-          && transaction.logs === '{"errors":["contract doesn\'t exist"]}') {
+        } else if (tickingAction) {
           // don't save logs
         } else {
           this.virtualTransactions.push(transaction);

--- a/libs/Constants.js
+++ b/libs/Constants.js
@@ -28,6 +28,55 @@ const CONSTANTS = {
   // default values
   ACCOUNT_RECEIVING_FEES: 'hive-engine',
   SSC_STORE_PRICE: '0.001',
+  // WARNING: Do not add any more entries to this initial configuration.
+  // Future contracts must use the contract action 'registerTick'.
+  INITIAL_CONTRACT_TICKS: [
+    {
+      contract: 'tokens',
+      action: 'checkPendingUnstakes',
+      startRefBlock: 0,
+    },
+    {
+      contract: 'tokens',
+      action: 'checkPendingUndelegations',
+      startRefBlock: 0,
+    },
+    {
+      contract: 'nft',
+      action: 'checkPendingUndelegations',
+      startRefBlock: 0,
+    },
+    {
+      contract: 'botcontroller',
+      action: 'tick',
+      startRefBlock: 45251626,
+    },
+    {
+      contract: 'mining',
+      action: 'checkPendingLotteries',
+      startRefBlock: 47746850,
+    },
+    {
+      contract: 'airdrops',
+      action: 'checkPendingAirdrops',
+      startRefBlock: 48664773,
+    },
+    {
+      contract: 'nftauction',
+      action: 'updateAuctions',
+      startRefBlock: 54560500,
+    },
+    {
+      contract: 'witnesses',
+      action: 'scheduleWitnesses',
+      startRefBlock: 51022551,
+    },
+    {
+      contract: 'tokenfunds',
+      action: 'checkPendingDtfs',
+      startRefBlock: 53610300,
+    },
+  ],
 };
 
 module.exports.CONSTANTS = CONSTANTS;

--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -264,13 +264,25 @@ class SmartContracts {
       if (contractTicks.find(t => t.contract === contractName && t.action === tickAction)) {
         return { logs: { errors: ['contract tick already registered'] } };
       }
-      contractTicks.push({
+      const newContractTick = {
         contract: contractName,
         action: tickAction,
         startRefBlock: refHiveBlockNumber + 1,
-      });
+      };
+      contractTicks.push(newContractTick);
       await database.updateContractsConfig(contractsConfig);
-      return { logs: { errors: [], events: [] } };
+      return {
+        logs: {
+          errors: [],
+          events: [
+            {
+              contract: 'contract',
+              event: 'registerTick',
+              data: newContractTick,
+            },
+          ],
+        },
+      };
     } catch (e) {
       return { logs: { errors: [`${e.name}: ${e.message}`] } };
     }

--- a/libs/SmartContracts.js
+++ b/libs/SmartContracts.js
@@ -248,6 +248,34 @@ class SmartContracts {
     }
   }
 
+  // register tick action
+  static async registerTick(database, transaction) {
+    try {
+      const { refHiveBlockNumber } = transaction;
+      const payload = JSON.parse(transaction.payload);
+      const { contractName, tickAction } = payload;
+
+      const existingContract = await database.findContract({ name: contractName });
+      if (!existingContract) {
+        return { logs: { errors: ['contract does not exist'] } };
+      }
+      const contractsConfig = await database.getContractsConfig();
+      const { contractTicks } = contractsConfig;
+      if (contractTicks.find(t => t.contract === contractName && t.action === tickAction)) {
+        return { logs: { errors: ['contract tick already registered'] } };
+      }
+      contractTicks.push({
+        contract: contractName,
+        action: tickAction,
+        startRefBlock: refHiveBlockNumber + 1,
+      });
+      await database.updateContractsConfig(contractsConfig);
+      return { logs: { errors: [], events: [] } };
+    } catch (e) {
+      return { logs: { errors: [`${e.name}: ${e.message}`] } };
+    }
+  }
+
   // execute the smart contract and perform actions on the database if needed
   static async executeSmartContract(
     database, transaction, blockNumber, timestamp, refHiveBlockId, prevRefHiveBlockId, jsVMTimeout,

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test14": "./node_modules/mocha/bin/mocha ./test/marketpools.js",
     "test15": "./node_modules/mocha/bin/mocha ./test/tokenfunds.js",
     "test16": "./node_modules/mocha/bin/mocha ./test/nftauction.js",
-    "test17": "./node_modules/mocha/bin/mocha ./test/comments.js"
+    "test17": "./node_modules/mocha/bin/mocha ./test/comments.js",
+    "test18": "./node_modules/mocha/bin/mocha ./test/ticks.js"
   },
   "engines": {
     "node": ">=13.7.0",

--- a/test/ticks.js
+++ b/test/ticks.js
@@ -1,0 +1,220 @@
+/* eslint-disable */
+const assert = require('assert').strict;
+const { MongoClient } = require('mongodb');
+const dhive = require('@hiveio/dhive');
+const enchex = require('crypto-js/enc-hex');
+
+const { CONSTANTS } = require('../libs/Constants');
+const { Database } = require('../libs/Database');
+const blockchain = require('../plugins/Blockchain');
+const { Transaction } = require('../libs/Transaction');
+const { setupContractPayload } = require('../libs/util/contractUtil');
+const { Fixture, conf } = require('../libs/util/testing/Fixture');
+const { TableAsserts } = require('../libs/util/testing/TableAsserts');
+const { assertError } = require('../libs/util/testing/Asserts');
+
+
+const fixture = new Fixture();
+const tableAsserts = new TableAsserts(fixture);
+
+const initialTickContracts = new Set(CONSTANTS.INITIAL_CONTRACT_TICKS.map(t => t.contract));
+
+async function getTickingActionsAtRefblock(refBlockNumber) {
+  const transactions = [];
+  transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'dummy', 'dummy', 'dummy', '{}'));
+  const block = {
+    refHiveBlockNumber: refBlockNumber,
+    refHiveBlockId: 'ABCD1',
+    prevRefHiveBlockId: 'ABCD2',
+    timestamp: '2018-06-01T00:00:00',
+    transactions,
+  };
+
+  await fixture.sendBlock(block);
+
+  const res = await fixture.database.getLatestBlockInfo();
+  return res.virtualTransactions.map(v => `${v.contract}.${v.action}`); 
+}
+
+describe('ticks', function () {
+  this.timeout(60000);
+
+  before((done) => {
+    new Promise(async (resolve) => {
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
+      db = await client.db(conf.databaseName);
+      await db.dropDatabase();
+      resolve();
+    })
+      .then(() => {
+        done()
+      })
+  });
+  
+  after((done) => {
+    new Promise(async (resolve) => {
+      await client.close();
+      resolve();
+    })
+      .then(() => {
+        done()
+      })
+  });
+
+  beforeEach((done) => {
+    new Promise(async (resolve) => {
+      db = await client.db(conf.databaseName);
+      resolve();
+    })
+      .then(() => {
+        done()
+      })
+  });
+
+  afterEach((done) => {
+      // runs after each test in this block
+      new Promise(async (resolve) => {
+        await db.dropDatabase()
+        resolve();
+      })
+        .then(() => {
+          done()
+        })
+  });
+  
+  it('should trigger ticks at expected refblock', (done) => {
+    new Promise(async (resolve) => {
+      await fixture.setUp();
+
+      let transactions = [];
+      let refBlockNumber = 1000;
+      initialTickContracts.forEach(c =>
+          transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update',
+              JSON.stringify(setupContractPayload(c, './contracts/testing/dummyTicks.js')))));
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      const expectedTickedActions = [
+        'tokens.checkPendingUnstakes',
+        'tokens.checkPendingUndelegations',
+        'nft.checkPendingUndelegations'
+      ];
+      let tickedActions = await getTickingActionsAtRefblock(1001);
+      assert.equal(JSON.stringify(tickedActions), JSON.stringify(expectedTickedActions));
+
+      tickedActions = await getTickingActionsAtRefblock(45251626);
+      expectedTickedActions.push('botcontroller.tick');
+      assert.equal(JSON.stringify(tickedActions), JSON.stringify(expectedTickedActions));
+
+      tickedActions = await getTickingActionsAtRefblock(47746850);
+      expectedTickedActions.push('mining.checkPendingLotteries');
+      assert.equal(JSON.stringify(tickedActions), JSON.stringify(expectedTickedActions));
+      
+      tickedActions = await getTickingActionsAtRefblock(48664773);
+      expectedTickedActions.push('airdrops.checkPendingAirdrops');
+      assert.equal(JSON.stringify(tickedActions), JSON.stringify(expectedTickedActions));
+
+      tickedActions = await getTickingActionsAtRefblock(51022551);
+      expectedTickedActions.push('witnesses.scheduleWitnesses');
+      assert.equal(JSON.stringify(tickedActions), JSON.stringify(expectedTickedActions));
+
+      tickedActions = await getTickingActionsAtRefblock(53610300);
+      expectedTickedActions.push('tokenfunds.checkPendingDtfs');
+      assert.equal(JSON.stringify(tickedActions), JSON.stringify(expectedTickedActions));
+
+      tickedActions = await getTickingActionsAtRefblock(54560500);
+      expectedTickedActions.push('nftauction.updateAuctions');
+      // manually checked since updateAuctions code was added before the others but at a later block
+      assert.equal(JSON.stringify(tickedActions), '["tokens.checkPendingUnstakes","tokens.checkPendingUndelegations","nft.checkPendingUndelegations","botcontroller.tick","mining.checkPendingLotteries","airdrops.checkPendingAirdrops","nftauction.updateAuctions","witnesses.scheduleWitnesses","tokenfunds.checkPendingDtfs"]');
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
+
+  it('should register tick', (done) => {
+    new Promise(async (resolve) => {
+      await fixture.setUp();
+
+      let transactions = [];
+      let refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update',
+              JSON.stringify(setupContractPayload('testtick', './contracts/testing/dummyTicks.js'))));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'registerTick',
+              '{ "contractName": "testtick", "tickAction": "tick"}'));
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      const tickedActions = await getTickingActionsAtRefblock(refBlockNumber);
+      assert.equal(JSON.stringify(tickedActions), '["testtick.tick"]');
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
+
+  it('should not register tick', (done) => {
+    new Promise(async (resolve) => {
+      await fixture.setUp();
+
+      let transactions = [];
+      let refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'registerTick',
+              '{ "contractName": "notexist", "tickAction": "tick"}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'unauthorized', 'contract', 'registerTick',
+              '{ "contractName": "tokens", "tickAction": "issue"}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'registerTick',
+              '{ "contractName": "tokens", "tickAction": "checkPendingUnstakes"}'));
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+      let res = await fixture.database.getLatestBlockInfo();
+      let txs = res.transactions;
+      assertError(txs[0], 'contract does not exist');
+      assertError(txs[1], 'registerTick unauthorized');
+      assertError(txs[2], 'contract tick already registered');
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      const tickedActions = await getTickingActionsAtRefblock(refBlockNumber);
+      assert.equal(JSON.stringify(tickedActions), '[]');
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
+});

--- a/test/ticks.js
+++ b/test/ticks.js
@@ -166,6 +166,10 @@ describe('ticks', function () {
       await fixture.sendBlock(block);
       await tableAsserts.assertNoErrorInLastBlock();
 
+      let res = await fixture.database.getLatestBlockInfo();
+      let txs = res.transactions;
+      assert.equal(txs[1].logs, `{"events":[{"contract":"contract","event":"registerTick","data":{"contract":"testtick","action":"tick","startRefBlock":${refBlockNumber + 1}}}]}`);
+
       refBlockNumber = fixture.getNextRefBlockNumber();
       const tickedActions = await getTickingActionsAtRefblock(refBlockNumber);
       assert.equal(JSON.stringify(tickedActions), '["testtick.tick"]');


### PR DESCRIPTION
Register all ticking contracts into "contracts_config" table. Allows for putting more global contract settings in the future. Add "registerTick" method for registering additional ticking actions.