### PR TITLE
Throttle by vote count in addition to max posts processed

### DIFF
--- a/contracts/comments.js
+++ b/contracts/comments.js
@@ -274,7 +274,7 @@ async function computePostRewards(params, rewardPool, token, endTimestamp) {
     },
     maxPostsProcessedPerRound,
     0,
-    [{ index: 'byCashoutTime', descending: false }]);
+    [{ index: 'byCashoutTime', descending: false }, { index: '_id', descending: false }]);
   let done = false;
   let deductFromRewardPool = api.BigNumber(0);
   let votesProcessed = 0;
@@ -322,7 +322,7 @@ async function postClaimsInInterval(params, rewardPool, start, end) {
     },
     maxPostsProcessedPerRound,
     postOffset,
-    [{ index: 'byCashoutTime', descending: false }]);
+    [{ index: 'byCashoutTime', descending: false }, { index: '_id', descending: false }]);
   while (postsToPayout && postsToPayout.length > 0) {
     newPendingClaims = newPendingClaims.plus(
       postsToPayout.reduce((x, y) => x.plus(calculateWeightRshares(rewardPool, y.voteRshareSum)),
@@ -340,7 +340,7 @@ async function postClaimsInInterval(params, rewardPool, start, end) {
       },
       maxPostsProcessedPerRound,
       postOffset,
-      [{ index: 'byCashoutTime', descending: false }]);
+      [{ index: 'byCashoutTime', descending: false }, { index: '_id', descending: false }]);
   }
   return newPendingClaims;
 }

--- a/contracts/comments.js
+++ b/contracts/comments.js
@@ -377,13 +377,10 @@ async function tokenMaintenance() {
     $expr: rewardPoolProcessingExpression,
     _id: { $gt: lastProcessedPoolId },
   }, maintenanceTokensPerBlock, 0, [{ index: '_id', descending: false }]);
-  if (!rewardPools) {
-    // try from beginning
-    rewardPools = await api.db.find('rewardPools', {
-      active: true,
-      $expr: rewardPoolProcessingExpression,
-    }, maintenanceTokensPerBlock, 0, [{ index: '_id', descending: false }]);
-  } else if (rewardPools.length < maintenanceTokensPerBlock) {
+  if (!rewardPools || rewardPools.length < maintenanceTokensPerBlock) {
+    if (!rewardPools) {
+      rewardPools = [];
+    }
     // augment from beginning
     const moreRewardPools = await api.db.find('rewardPools', {
       active: true,


### PR DESCRIPTION
Provides a more stable token maintenance mechanism, using the rewardInterval for how often to increment rewards and do post payout computation.

Moreover, within the same reward interval, we will process all posts within this interval together, possibly spread over multiple maintenance periods

In order to schedule multiple tokens fairly, we change the token maintenance order by looping and iterating by ID instead of by processing timestamp.