### PR TITLE
pools - separate slippage and price impact, add minOut and maxIn

### DIFF
--- a/contracts/marketpools.js
+++ b/contracts/marketpools.js
@@ -94,21 +94,7 @@ async function validateOracle(pool, newPrice, maxDeviation = api.BigNumber('0.01
   if (!baseMetrics || !quoteMetrics) return null; // no oracle available
   const oracle = api.BigNumber(baseMetrics.lastPrice).dividedBy(quoteMetrics.lastPrice);
   const dev = api.BigNumber(newPrice).minus(oracle).abs().dividedBy(oracle);
-  // api.debug(`${oracle} -> ${dev} / ${maxDeviation}`);
   if (!api.assert(api.BigNumber(dev).lte(maxDeviation), 'exceeded max deviation from order book')) return false;
-  return true;
-}
-
-function validateSwap(pool, baseDelta, quoteDelta, maxSlippage) {
-  const k = api.BigNumber(pool.baseQuantity).times(pool.quoteQuantity).toFixed(pool.precision, api.BigNumber.ROUND_HALF_UP);
-  const baseAdjusted = api.BigNumber(pool.baseQuantity).plus(baseDelta);
-  const quoteAdjusted = api.BigNumber(pool.quoteQuantity).plus(quoteDelta);
-  const kAdjusted = api.BigNumber(baseAdjusted).times(quoteAdjusted).toFixed(pool.precision, api.BigNumber.ROUND_HALF_UP);
-  const p = api.BigNumber(pool.quoteQuantity).dividedBy(pool.baseQuantity).toFixed(pool.precision, api.BigNumber.ROUND_HALF_UP);
-  const pAdjusted = api.BigNumber(quoteAdjusted).dividedBy(baseAdjusted).toFixed(pool.precision, api.BigNumber.ROUND_HALF_UP);
-  const slippage = api.BigNumber(pAdjusted).minus(p).abs().dividedBy(p);
-  if (!api.assert(api.BigNumber(slippage).lte(maxSlippage), 'exceeded max slippage for swap')) return false;
-  if (!api.assert(api.BigNumber(kAdjusted).eq(k), `constant product ${kAdjusted}, expected ${k}`)) return false;
   return true;
 }
 
@@ -298,7 +284,7 @@ actions.addLiquidity = async (payload) => {
     tokenPair,
     baseQuantity,
     quoteQuantity,
-    maxSlippage,
+    maxPriceImpact,
     maxDeviation,
     isSignedWithActiveKey,
   } = payload;
@@ -308,11 +294,11 @@ actions.addLiquidity = async (payload) => {
     || !api.assert(typeof quoteQuantity === 'string' && api.BigNumber(quoteQuantity).gt(0), 'invalid quoteQuantity')
     || !await validateTokenPair(tokenPair)) return;
 
-  let addSlippage = api.BigNumber('0.01');
-  if (maxSlippage) {
-    if (!api.assert(typeof maxSlippage === 'string' && api.BigNumber(maxSlippage).gt(0) && api.BigNumber(maxSlippage).lt(50)
-      && api.BigNumber(maxSlippage).dp() <= 3, 'maxSlippage must be greater than 0 and less than 50')) return;
-    addSlippage = api.BigNumber(maxSlippage).dividedBy(100);
+  let addPriceImpact = api.BigNumber('0.01');
+  if (maxPriceImpact) {
+    if (!api.assert(typeof maxPriceImpact === 'string' && api.BigNumber(maxPriceImpact).gt(0)
+      && api.BigNumber(maxPriceImpact).dp() <= 3, 'maxPriceImpact must be greater than 0')) return;
+    addPriceImpact = api.BigNumber(maxPriceImpact).dividedBy(100);
   }
 
   let addDeviation = api.BigNumber('0.01');
@@ -336,17 +322,17 @@ actions.addLiquidity = async (payload) => {
       && await validateOracle(pool, api.BigNumber(quoteQuantity).dividedBy(baseQuantity), addDeviation) === false) return;
 
     let amountAdjusted;
-    const baseMin = api.BigNumber(baseQuantity).times(api.BigNumber('1').minus(addSlippage));
-    const quoteMin = api.BigNumber(quoteQuantity).times(api.BigNumber('1').minus(addSlippage));
+    const baseMin = api.BigNumber(baseQuantity).times(api.BigNumber('1').minus(addPriceImpact));
+    const quoteMin = api.BigNumber(quoteQuantity).times(api.BigNumber('1').minus(addPriceImpact));
     if (api.BigNumber(pool.baseQuantity).gt(0) && api.BigNumber(pool.quoteQuantity).gt(0)) {
       const quoteOptimal = getQuote(baseQuantity, pool.baseQuantity, pool.quoteQuantity).toFixed(quoteToken.precision, api.BigNumber.ROUND_HALF_UP);
       if (api.BigNumber(quoteOptimal).lte(quoteQuantity)) {
-        if (!api.assert(api.BigNumber(quoteOptimal).gte(quoteMin), 'exceeded max slippage for adding liquidity')) return;
+        if (!api.assert(api.BigNumber(quoteOptimal).gte(quoteMin), 'exceeded max price impact for adding liquidity')) return;
         amountAdjusted = [baseQuantity, quoteOptimal];
       } else {
         const baseOptimal = getQuote(quoteQuantity, pool.quoteQuantity, pool.baseQuantity).toFixed(baseToken.precision, api.BigNumber.ROUND_HALF_UP);
         if (api.BigNumber(baseOptimal).lte(baseQuantity)) {
-          if (!api.assert(api.BigNumber(baseOptimal).gte(baseMin), 'exceeded max slippage for adding liquidity')) return;
+          if (!api.assert(api.BigNumber(baseOptimal).gte(baseMin), 'exceeded max price impact for adding liquidity')) return;
           amountAdjusted = [baseOptimal, quoteQuantity];
         }
       }
@@ -456,19 +442,23 @@ actions.swapTokens = async (payload) => {
     tokenSymbol,
     tokenAmount,
     tradeType,
-    maxSlippage,
+    minAmountOut,
+    maxAmountIn,
     isSignedWithActiveKey,
   } = payload;
 
   if (!api.assert(isSignedWithActiveKey === true, 'you must use a transaction signed with your active key')
     || !api.assert(typeof tokenSymbol === 'string', 'invalid token')
     || !api.assert(typeof tokenAmount === 'string' && api.BigNumber(tokenAmount).gt(0), 'insufficient tokenAmount')
-    || !api.assert(typeof maxSlippage === 'string' && api.BigNumber(maxSlippage).gt(0) && api.BigNumber(maxSlippage).lt(50)
-      && api.BigNumber(maxSlippage).dp() <= 3, 'maxSlippage must be greater than 0 and less than 50')
     || !api.assert(typeof tradeType === 'string' && TradeType.indexOf(tradeType) !== -1, 'invalid tradeType')
     || !await validateTokenPair(tokenPair)) {
     return;
   }
+  if (minAmountOut && !api.assert(typeof minAmountOut === 'string'
+    && api.BigNumber(minAmountOut).gt(0), 'insufficient minAmountOut')) return;
+  if (maxAmountIn && !api.assert(typeof maxAmountIn === 'string'
+    && api.BigNumber(maxAmountIn).gt(0), 'insufficient maxAmountIn')) return;
+  if (!api.assert(!(minAmountOut && maxAmountIn), 'specify minAmountOut or maxAmountIn but not both')) return;
 
   const [baseSymbol, quoteSymbol] = tokenPair.split(':');
   const pool = await api.db.findOne('pools', { tokenPair });
@@ -513,13 +503,22 @@ actions.swapTokens = async (payload) => {
     if (!api.assert(api.BigNumber(tokenQuantity.out).dp() <= tokenOut.precision, 'symbolOut precision mismatch')) return;
   }
 
+  if (!api.assert(senderBaseFunded, 'insufficient input balance')) return;
+
   tokenQuantity.in = api.BigNumber(tokenQuantity.in).dp(tokenIn.precision, api.BigNumber.ROUND_CEIL);
   tokenQuantity.out = api.BigNumber(tokenQuantity.out).dp(tokenOut.precision, api.BigNumber.ROUND_DOWN);
   if (!api.assert(tokenQuantity.in.gt(0), 'symbolIn precision mismatch')
     || !api.assert(tokenQuantity.out.gt(0), 'symbolOut precision mismatch')) return;
-
-  if (!api.assert(senderBaseFunded, 'insufficient input balance')
-    || !validateSwap(pool, tokenPairDelta[0], tokenPairDelta[1], api.BigNumber(maxSlippage).dividedBy(100))) return;
+  if (minAmountOut) {
+    if (!api.assert(api.BigNumber(minAmountOut).dp() <= tokenOut.precision, 'minAmountOut precision mismatch')) return;
+    tokenQuantity.minOut = api.BigNumber(minAmountOut);
+  }
+  if (maxAmountIn) {
+    if (!api.assert(api.BigNumber(maxAmountIn).dp() <= tokenIn.precision, 'maxAmountIn precision mismatch')) return;
+    tokenQuantity.maxIn = api.BigNumber(maxAmountIn);
+  }
+  if (tokenQuantity.minOut !== undefined && !api.assert(api.BigNumber(tokenQuantity.out).gte(tokenQuantity.minOut), 'exceeded max slippage for swap')) return;
+  if (tokenQuantity.maxIn !== undefined && !api.assert(api.BigNumber(tokenQuantity.in).lte(tokenQuantity.maxIn), 'exceeded max slippage for swap')) return;
 
   const res = await api.executeSmartContract('tokens', 'transferToContract', { symbol: symbolIn, quantity: tokenQuantity.in.toFixed(), to: 'marketpools' });
   if (res.errors === undefined

--- a/test/marketpools.js
+++ b/test/marketpools.js
@@ -322,7 +322,7 @@ describe('marketpools tests', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'whale', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1000.1234567899", "quoteQuantity": "16000", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'issue', '{ "symbol": "SLV", "quantity": "16000", "to": "halfwhale", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'halfwhale', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1000", "quoteQuantity": "16000", "isSignedWithActiveKey": true }'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1", "quoteQuantity": "100", "maxSlippage": "99", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1", "quoteQuantity": "100", "maxPriceImpact": "0", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "100", "quoteQuantity": "1", "isSignedWithActiveKey": true }'));      
 
       let block = {
@@ -342,12 +342,12 @@ describe('marketpools tests', function () {
       assertError(txs[7], 'invalid baseQuantity');
       assertError(txs[8], 'invalid quoteQuantity');
       assertError(txs[9], 'quoteSymbol does not exist');
-      assertError(txs[15], 'exceeded max slippage for adding liquidity');
+      assertError(txs[15], 'exceeded max price impact for adding liquidity');
       assertError(txs[16], 'insufficient token balance');
       assertError(txs[17], 'baseQuantity precision mismatch');
       assertError(txs[19], 'insufficient token balance');
-      assertError(txs[20], 'maxSlippage must be greater than 0 and less than 50');
-      assertError(txs[21], 'exceeded max slippage for adding liquidity');
+      assertError(txs[20], 'maxPriceImpact must be greater than 0');
+      assertError(txs[21], 'exceeded max price impact for adding liquidity');
       
       res = await fixture.database.findOne({
         contract: 'marketpools',
@@ -466,7 +466,7 @@ describe('marketpools tests', function () {
       await fixture.sendBlock(block);
 
       let res = await fixture.database.getLatestBlockInfo();
-      console.log(res);
+      // console.log(res);
       let txs = res.transactions;
 
       assertError(txs[15], 'exceeded max deviation from order book');
@@ -512,8 +512,8 @@ describe('marketpools tests', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1000", "quoteQuantity": "16000", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'whale', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1", "quoteQuantity": "16", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1", "quoteQuantity": "16", "isSignedWithActiveKey": true }'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'whale', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "SLV", "tokenAmount": "1.234", "tradeType": "exactOutput", "maxSlippage": "0.5", "isSignedWithActiveKey": true}'));      
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "0.03987654", "quoteQuantity": "0.62476567", "maxSlippage": "10", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'whale', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "SLV", "tokenAmount": "1.234", "tradeType": "exactOutput", "maxPriceImpact": "0.5", "isSignedWithActiveKey": true}'));      
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "0.03987654", "quoteQuantity": "0.62476567", "maxPriceImpact": "10", "isSignedWithActiveKey": true }'));
 
       let block = {
         refHiveBlockNumber: refBlockNumber,
@@ -579,8 +579,8 @@ describe('marketpools tests', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1000", "quoteQuantity": "16000", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'whale', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1", "quoteQuantity": "16", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1", "quoteQuantity": "16", "isSignedWithActiveKey": true }'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "SLV", "tokenAmount": "1.234", "tradeType": "exactOutput", "maxSlippage": "0.5", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1.02555", "quoteQuantity": "15.997", "maxSlippage": "10", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "SLV", "tokenAmount": "1.234", "tradeType": "exactOutput", "maxPriceImpact": "0.5", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1.02555", "quoteQuantity": "15.997", "maxPriceImpact": "10", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "GLD:SLV", "baseQuantity": "1", "quoteQuantity": "16.1", "isSignedWithActiveKey": true }'));
 
       let block = {
@@ -791,16 +791,17 @@ describe('marketpools tests', function () {
       await tableAsserts.assertNoErrorInLastBlock();
       refBlockNumber = fixture.getNextRefBlockNumber();
       transactions = [];
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "1010", "tradeType": "exactOutput", "maxSlippage": "1", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "SLV", "tokenAmount": "1000", "tradeType": "exactOutput", "maxSlippage": "1", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "2000", "tradeType": "exactInput", "maxSlippage": "1", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "SLV", "tokenAmount": "2000", "tradeType": "exactInput", "maxSlippage": "1", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLDSLV", "tokenSymbol": "GLD", "tokenAmount": "1", "tradeType": "exactInput", "maxSlippage": "1", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "2", "tradeType": "exactOutput", "maxSlippage": "1", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "2.1234567899", "tradeType": "exactOutput", "maxSlippage": "5", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "2", "tradeType": "exactOutput", "maxSlippage": "0", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "2", "tradeType": "exactOutput", "isSignedWithActiveKey": true}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "2", "tradeType": "x", "maxSlippage": "1", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "1010", "tradeType": "exactOutput", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "SLV", "tokenAmount": "1000", "tradeType": "exactOutput", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "2000", "tradeType": "exactInput", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "SLV", "tokenAmount": "2000", "tradeType": "exactInput", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLDSLV", "tokenSymbol": "GLD", "tokenAmount": "1", "tradeType": "exactInput", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "1", "tradeType": "exactInput", "minAmountOut": "0", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "1", "tradeType": "exactInput", "minAmountOut": "1", "maxAmountIn": "1", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "SLV", "tokenAmount": "1", "tradeType": "exactInput", "minAmountOut": "1", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "1", "tradeType": "exactOutput", "maxAmountIn": "10", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "2.1234567899", "tradeType": "exactOutput", "isSignedWithActiveKey": true}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'buyer', 'marketpools', 'swapTokens', '{ "tokenPair": "GLD:SLV", "tokenSymbol": "GLD", "tokenAmount": "2", "tradeType": "x", "isSignedWithActiveKey": true}'));
 
       block = {
         refHiveBlockNumber: refBlockNumber,
@@ -820,11 +821,12 @@ describe('marketpools tests', function () {
       assertError(txs[2], 'insufficient input balance');
       assertError(txs[3], 'insufficient input balance');
       assertError(txs[4], 'invalid tokenPair format');
-      assertError(txs[5], 'exceeded max slippage for swap');
-      assertError(txs[6], 'symbolOut precision mismatch');
-      assertError(txs[7], 'maxSlippage must be greater than 0 and less than 50');
-      assertError(txs[8], 'maxSlippage must be greater than 0 and less than 50');
-      assertError(txs[9], 'invalid tradeType');
+      assertError(txs[5], 'insufficient minAmountOut');
+      assertError(txs[6], 'specify minAmountOut or maxAmountIn but not both');
+      assertError(txs[7], 'exceeded max slippage for swap');
+      assertError(txs[8], 'exceeded max slippage for swap');
+      assertError(txs[9], 'symbolOut precision mismatch');
+      assertError(txs[10], 'invalid tradeType');
      
       resolve();
     })


### PR DESCRIPTION
- Slippage protection for `swapTokens` using optional parameters `minAmountOut` / `maxAmountIn` depending on trade direction. Transactions without these parameters or those that specify `maxSlippage` can still be executed. `maxSlippage` in the swapTokens action no longer has any effect.
- Price impact control is retained for adding liquidity. It is no longer applied to `swapTokens`.
