### PR TITLE
Distribution: bonus curve adjustment fix

### DIFF
--- a/contracts/marketpools.js
+++ b/contracts/marketpools.js
@@ -362,11 +362,13 @@ actions.addLiquidity = async (payload) => {
     if (lp) {
       const existingShares = lp.shares;
       const finalShares = api.BigNumber(lp.shares).plus(newShares);
-      const timeOffset = api.BigNumber(finalShares).minus(existingShares).abs().dividedBy(existingShares);
+      const timePassed = api.BigNumber(blockDate.getTime()).minus(lp.timeFactor).abs();
+      const diffShares = api.BigNumber(finalShares).minus(existingShares).abs().dividedBy(api.BigNumber.max(finalShares, existingShares));
+      const timeOffset = api.BigNumber(timePassed).times(diffShares);
       lp.shares = finalShares;
       lp.timeFactor = api.BigNumber.min(
         api.BigNumber(lp.timeFactor)
-          .times(api.BigNumber('1').plus(timeOffset))
+          .plus(timeOffset)
           .dp(0, api.BigNumber.ROUND_HALF_UP),
         blockDate.getTime(),
       ).toNumber();

--- a/test/distribution.js
+++ b/test/distribution.js
@@ -63,6 +63,15 @@ async function assertDistTokenBalance(id, symbol, balance) {
   assert.ok(hasBalance, `No balance for contract ${id}, ${symbol}`);
 }
 
+async function assertTimeFactor(account, tokenPair, timeFactor) {
+  let lp = await fixture.database.findOne({
+    contract: 'marketpools',
+    table: 'liquidityPositions',
+    query: { account, tokenPair },
+  });
+  assert.equal(lp.timeFactor, timeFactor, `LP has timeFactor ${lp.timeFactor}, expected ${timeFactor}`);
+}
+
 async function assertAllErrorInLastBlock() {
   const transactions = (await fixture.database.getLatestBlockInfo()).transactions;
   for (let i = 0; i < transactions.length; i++) {
@@ -1381,6 +1390,145 @@ describe('distribution', function () {
       });
 
   });  
+
+
+  it('should adjust bonus curve', (done) => {
+    new Promise(async (resolve) => {
+
+      await fixture.setUp();
+      await setUpEnv();
+
+      let refBlockNumber = fixture.getNextRefBlockNumber();
+      let transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "symbol": "TKNA", "precision": 8, "maxSupply": "10000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "symbol": "TKNB", "precision": 8, "maxSupply": "10000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'issue', '{ "symbol": "TKNA", "quantity": "2000", "to": "donchate", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'issue', '{ "symbol": "TKNB", "quantity": "2000", "to": "donchate", "isSignedWithActiveKey": true }'));      
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'issue', '{ "symbol": "TKNA", "quantity": "2000", "to": "investor", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'issue', '{ "symbol": "TKNB", "quantity": "2000", "to": "investor", "isSignedWithActiveKey": true }'));      
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'issue', '{ "symbol": "TKNA", "quantity": "3000", "to": "whale", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'issue', '{ "symbol": "TKNB", "quantity": "3000", "to": "whale", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'issue', '{ "symbol": "TKNA", "quantity": "1000", "to": "minnow", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'tokens', 'issue', '{ "symbol": "TKNB", "quantity": "1000", "to": "minnow", "isSignedWithActiveKey": true }'));                              
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'marketpools', 'createPool', '{ "tokenPair": "TKNA:TKNB", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "TKNA:TKNB", "baseQuantity": "1", "quoteQuantity": "10", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'minnow', 'marketpools', 'addLiquidity', '{ "tokenPair": "TKNA:TKNB", "baseQuantity": "0.5", "quoteQuantity": "5", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'distribution', 'create', '{ "strategy": "pool", "tokenPair": "TKNA:TKNB", "numTicks": "100", "bonusCurve": { "numPeriods": "100", "periodBonusPct": "1" }, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'distribution', 'setActive', '{ "id": 1, "active": "true", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'distribution', 'deposit', '{ "id": 1, "symbol": "BEE", "quantity": "100", "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'donchate', 'distribution', 'deposit', '{ "id": 1, "symbol": "TKNA", "quantity": "100", "isSignedWithActiveKey": true }'));
+      
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'placeholder', 'empty', 'empty', '{}'));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-02T00:00:00',
+        transactions,
+      };
+      await fixture.sendBlock(block);
+      res = await fixture.database.getLatestBlockInfo();
+      // console.log(res);
+      assert.ok(res.virtualTransactions.length > 0, 'Expected to find virtualTransactions');
+
+      await tableAsserts.assertUserBalances({ account: 'donchate', symbol: 'BEE', balance: '3200.00000000'});
+      await tableAsserts.assertUserBalances({ account: 'investor', symbol: 'BEE', balance: '0.66666666'});
+      await tableAsserts.assertUserBalances({ account: 'whale', symbol: 'BEE' });
+      await tableAsserts.assertUserBalances({ account: 'minnow', symbol: 'BEE', balance: '0.33333333'});
+      await assertDistTokenBalance(1, 'BEE', '99.00000001');
+
+      await tableAsserts.assertUserBalances({ account: 'donchate', symbol: 'TKNA', balance: '1900.00000000'});
+      await tableAsserts.assertUserBalances({ account: 'investor', symbol: 'TKNA', balance: '1999.66666666'});
+      await tableAsserts.assertUserBalances({ account: 'whale', symbol: 'TKNA', balance: '3000'});
+      await tableAsserts.assertUserBalances({ account: 'minnow', symbol: 'TKNA', balance: '999.83333333'});
+      await assertDistTokenBalance(1, 'TKNA', '99.00000001');
+      await assertTimeFactor('investor', 'TKNA:TKNB', '1527811200000');
+      await assertTimeFactor('minnow', 'TKNA:TKNB', '1527811200000');
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'investor', 'marketpools', 'addLiquidity', '{ "tokenPair": "TKNA:TKNB", "baseQuantity": "1", "quoteQuantity": "10", "isSignedWithActiveKey": true }'));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-03T00:00:00',
+        transactions,
+      };
+      await fixture.sendBlock(block);
+      res = await fixture.database.getLatestBlockInfo();
+      // console.log(res);
+      assert.ok(res.virtualTransactions.length > 0, 'Expected to find virtualTransactions');
+
+      await tableAsserts.assertUserBalances({ account: 'donchate', symbol: 'BEE', balance: '3200.00000000'});
+      await tableAsserts.assertUserBalances({ account: 'investor', symbol: 'BEE', balance: '1.46347940'});
+      await tableAsserts.assertUserBalances({ account: 'whale', symbol: 'BEE' });
+      await tableAsserts.assertUserBalances({ account: 'minnow', symbol: 'BEE', balance: '0.53652058' });
+      await assertDistTokenBalance(1, 'BEE', '98.00000002');
+
+      await tableAsserts.assertUserBalances({ account: 'donchate', symbol: 'TKNA', balance: '1900.00000000'});
+      await tableAsserts.assertUserBalances({ account: 'investor', symbol: 'TKNA', balance: '1999.46347940'});
+      await tableAsserts.assertUserBalances({ account: 'whale', symbol: 'TKNA', balance: '3000'});
+      await tableAsserts.assertUserBalances({ account: 'minnow', symbol: 'TKNA', balance: '1000.03652058'});
+      await assertDistTokenBalance(1, 'TKNA', '98.00000002');
+      await assertTimeFactor('investor', 'TKNA:TKNB', '1527897600000');
+      await assertTimeFactor('minnow', 'TKNA:TKNB', '1527811200000');
+
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'placeholder', 'empty', 'empty', '{}'));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-04T00:00:00',
+        transactions,
+      };
+      await fixture.sendBlock(block);
+      res = await fixture.database.getLatestBlockInfo();
+      // console.log(res);
+      assert.ok(res.virtualTransactions.length > 0, 'Expected to find virtualTransactions');
+
+      await tableAsserts.assertUserBalances({ account: 'donchate', symbol: 'BEE', balance: '3200.00000000'});
+      await tableAsserts.assertUserBalances({ account: 'investor', symbol: 'BEE', balance: '2.26191384'});
+      await tableAsserts.assertUserBalances({ account: 'whale', symbol: 'BEE' });
+      await tableAsserts.assertUserBalances({ account: 'minnow', symbol: 'BEE', balance: '0.73808613'});
+      await assertDistTokenBalance(1, 'BEE', '97.00000003');
+
+      await tableAsserts.assertUserBalances({ account: 'donchate', symbol: 'TKNA', balance: '1900.00000000'});
+      await tableAsserts.assertUserBalances({ account: 'investor', symbol: 'TKNA', balance: '2000.26191384'});
+      await tableAsserts.assertUserBalances({ account: 'whale', symbol: 'TKNA', balance: '3000'});
+      await tableAsserts.assertUserBalances({ account: 'minnow', symbol: 'TKNA', balance: '1000.23808613'});
+      await assertDistTokenBalance(1, 'TKNA', '97.00000003');
+      await assertTimeFactor('investor', 'TKNA:TKNB', '1527897600000');
+      await assertTimeFactor('minnow', 'TKNA:TKNB', '1527811200000');
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+
+  });
 
   /// END TESTS
 });


### PR DESCRIPTION
- The adjustment to `timeFactor` when liquidity is added was not working as intended. It was resetting to current block time in essentially all cases. The changes in this PR correct this.
- Tests for these operations are in the `distribution` contract test suite.

Intended functionality:
Example: a position is increased by 100% (doubled) on period 4 after initial deposit; timeFactor will be increased by 2 periods / bonus level will be reduced by 2 periods. After adding liquidity the effective bonus shares remains consistent.

The 24 hour holding time remains in effect to prevent abuse, and with this correction to timeFactor, should only affect a small number of situations where liquidity is added and then increased by a great order of magnitude shortly after.