### PR TITLE
Catch Mongo errors and propagate to logging

### DIFF
--- a/libs/Block.js
+++ b/libs/Block.js
@@ -99,7 +99,7 @@ class Block {
 
     // Comments contract causing issues and needs to be reverted. put at beginning
     if (this.refHiveBlockNumber === 58637536) {
-        this.transactions.unshift(new Transaction(this.blockNumber, 'FIXTX_COMMENTS_REVERT', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(revertCommentsContractPayload)));
+      this.transactions.unshift(new Transaction(this.blockNumber, 'FIXTX_COMMENTS_REVERT', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(revertCommentsContractPayload)));
     }
   }
 
@@ -246,6 +246,9 @@ class Block {
       }
     } else {
       results = { logs: { errors: ['the parameters sender, contract and action are required'] } };
+    }
+    if (results.logs && results.logs.errors && results.logs.errors.find(m => m.includes('MongoError'))) {
+      console.error(`Mongo tx error, transaction: ${JSON.stringify(transaction)}, result: ${JSON.stringify(results)}`); // eslint-disable-line no-console
     }
 
     await database.flushCache();


### PR DESCRIPTION
This would have caught the duplicate key error a lot sooner, and will expose future issues with Mongo related errors when running contracts.