### PR TITLE
Rollforward: Keep track of previously processed posts

### DIFF
--- a/contracts/comments.js
+++ b/contracts/comments.js
@@ -820,7 +820,7 @@ actions.comment = async (payload) => {
   if (existingPost) {
     return;
   }
-  
+
   await api.db.insert('postMetadata', { authorperm, rewardPoolIds });
 
   const blockDate = new Date(`${api.hiveBlockTimestamp}.000Z`);

--- a/libs/Block.js
+++ b/libs/Block.js
@@ -99,7 +99,7 @@ class Block {
 
     // Comments contract causing issues and needs to be reverted. put at beginning
     if (this.refHiveBlockNumber === 58637536) {
-        this.transactions.unshift(new Transaction(this.blockNumber, 'FIXTX_COMMENTS_REVERT', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(revertCommentsContractPayload)));
+      this.transactions.unshift(new Transaction(this.blockNumber, 'FIXTX_COMMENTS_REVERT', CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(revertCommentsContractPayload)));
     }
   }
 
@@ -246,6 +246,9 @@ class Block {
       }
     } else {
       results = { logs: { errors: ['the parameters sender, contract and action are required'] } };
+    }
+    if (results.logs && results.logs.errors && results.logs.errors.find(m => m.includes('MongoError'))) {
+      throw new Error(`Mongo tx error, transaction: ${JSON.stringify(transaction)}, result: ${JSON.stringify(results)}`);
     }
 
     await database.flushCache();

--- a/test/comments.js
+++ b/test/comments.js
@@ -18,7 +18,7 @@ const tokensContractPayload = setupContractPayload('tokens', './contracts/tokens
 const tokenfundsContractPayload = setupContractPayload('tokenfunds', './contracts/tokenfunds.js');
 const miningContractPayload = setupContractPayload('mining', './contracts/mining.js');
 const witnessContractPayload = setupContractPayload('witnesses', './contracts/witnesses.js');
-const commentsContractPayload = setupContractPayload('comments', './contracts/comments.js');
+const commentsContractPayload = setupContractPayload('comments', './contracts/comments.js', (contractCode) => contractCode.replace(/POST_QUERY_LIMIT = .*;/, 'POST_QUERY_LIMIT = 1;'));
 
 const fixture = new Fixture();
 const tableAsserts = new TableAsserts(fixture);
@@ -953,6 +953,87 @@ describe('comments', function () {
       assertError(txs[0], 'action must use comment operation');
       assertError(txs[1], 'rewardPools must be an array of integers');
       assertError(txs[2], 'rewardPools must be an array of integers');
+
+      const posts = await fixture.database.find({ contract: 'comments', table: 'posts', query: {}});
+      assert.equal(posts.length, 0);
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
+
+  it('should not reactivate comment after payout', (done) => {
+    new Promise(async (resolve) => {
+      await fixture.setUp();
+
+      await setUpRewardPool({ postRewardCurveParameter: "1", curationRewardCurveParameter: "0.5"});
+
+      let transactions;
+      let refBlockNumber;
+      let block;
+
+      transactions = [];
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'null', 'comments', 'comment', '{ "author": "author1", "permlink": "test1", "rewardPools": [1] }'));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      let posts = await fixture.database.find({ contract: 'comments', table: 'posts', query: {}});
+      assert.equal(JSON.stringify(posts), '[{"_id":{"authorperm":"@author1/test1","rewardPoolId":1},"rewardPoolId":1,"symbol":"TKN","authorperm":"@author1/test1","author":"author1","created":1527811200000,"cashoutTime":1528416000000,"votePositiveRshareSum":"0","voteRshareSum":"0"}]');
+      let postMetadata = await fixture.database.findOne({ contract: 'comments', table: 'postMetadata', query: { authorperm: "@author1/test1" }});
+      assert.equal(JSON.stringify(postMetadata), '{"_id":{"authorperm":"@author1/test1"},"authorperm":"@author1/test1","rewardPoolIds":[1]}');
+
+      // catch up post maintenance
+      await forwardPostMaintenanceAndAssertIssue('2018-06-07T23:59:57', "302398.50000000");
+
+      // forward clock and then pay out post
+      transactions = [];
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions.push(maintenanceOp(refBlockNumber));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-08T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      posts = await fixture.database.find({ contract: 'comments', table: 'posts', query: {}});
+      assert.equal(JSON.stringify(posts), '[]');
+
+      transactions = [];
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'null', 'comments', 'comment', '{ "author": "author1", "permlink": "test1", "rewardPools": [1] }'));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-08T00:00:03',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      posts = await fixture.database.find({ contract: 'comments', table: 'posts', query: {}});
+      assert.equal(JSON.stringify(posts), '[]');
 
       resolve();
     })


### PR DESCRIPTION
Rollforward of #111  with fix.

Fixes interval adding all posts within range, and allows comments to paid out posts to be properly indexed, and does not allow comments to re-activate after payout.

Adds new table called 'postMetadata' that maps authorperm to rewardPoolIds. Can be extended to store more in the future if needed. Lookups are by primary key _id, should be efficient, and does not affect the index for posts for a given reward pool.

This also adds a node change to make it so that MongoErrors properly error out completely rather than allow the node to infinite loop.