### PR TITLE
Nft miner fix handle nft change

### DIFF
--- a/contracts/mining.js
+++ b/contracts/mining.js
@@ -1062,7 +1062,9 @@ actions.handleStakeChange = async (payload) => {
   }
 };
 
-actions.handleNftChange = async (payload) => {
+actions.handleNftChange = async (payload) => {};
+
+actions.handleNftDelegationChange = async (payload) => {
   const {
     symbol, nft, add, callingContractInfo,
   } = payload;
@@ -1073,6 +1075,9 @@ actions.handleNftChange = async (payload) => {
       if (pool.updating.inProgress
           && pool.updating.tokenIndex === pool.tokenMiners.length
           && pool.updating.lastId < nft._id) {
+        return;
+      }
+      if (!pool.active) {
         return;
       }
       if (!pool.nftTokenMiner) {

--- a/contracts/mining.js
+++ b/contracts/mining.js
@@ -682,8 +682,6 @@ actions.setActive = async (payload) => {
   }
   const pool = await api.db.findOne('pools', { id });
   if (api.assert(pool, 'pool id not found')) {
-    pool.active = !!active;
-
     const minedTokenObject = await api.db.findOneInTable('tokens', 'tokens', { symbol: pool.minedToken });
     // eslint-disable-next-line no-template-curly-in-string
     if (api.assert(minedTokenObject && (minedTokenObject.issuer === api.sender || (minedTokenObject.symbol === "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'" && api.sender === api.owner)), 'must be issuer of minedToken')) {
@@ -691,6 +689,16 @@ actions.setActive = async (payload) => {
       pool.nextLotteryTimestamp = api.BigNumber(blockDate.getTime())
         .plus(pool.lotteryIntervalHours * 3600 * 1000).toNumber();
 
+      const { nftTokenMiner } = pool;
+      if (nftTokenMiner) {
+        const nftTokenPool = await api.db.findOne('nftTokenPools', { symbol: nftTokenMiner.symbol, id: pool.id });
+        if (active && !nftTokenPool) {
+          await api.db.insert('nftTokenPools', { symbol: nftTokenMiner.symbol, id: pool.id });
+        } else if (!active && nftTokenPool) {
+          await api.db.remove('nftTokenPools', nftTokenPool);
+        }
+      }
+      pool.active = !!active;
       await api.db.update('pools', pool);
     }
   }

--- a/contracts/mining.js
+++ b/contracts/mining.js
@@ -1062,7 +1062,7 @@ actions.handleStakeChange = async (payload) => {
   }
 };
 
-actions.handleNftChange = async (payload) => {};
+actions.handleNftChange = async () => {};
 
 actions.handleNftDelegationChange = async (payload) => {
   const {
@@ -1121,6 +1121,9 @@ actions.handleNftSetProperty = async (payload) => {
       if (pool.updating.inProgress
           && pool.updating.tokenIndex === pool.tokenMiners.length
           && pool.updating.lastId < nft._id) {
+        return;
+      }
+      if (!pool.active) {
         return;
       }
       if (!pool.nftTokenMiner) {

--- a/contracts/nft.js
+++ b/contracts/nft.js
@@ -1197,7 +1197,7 @@ actions.delegate = async (payload) => {
                     from: finalFrom, fromType: nftInstance.ownedBy, to: finalTo, toType: newOwnedBy, symbol, id,
                   });
 
-                  await api.executeSmartContract('mining', 'handleNftChange', { symbol, nft: nftInstance, add: true });
+                  await api.executeSmartContract('mining', 'handleNftDelegationChange', { symbol, nft: nftInstance, add: true });
                 }
               }
             }
@@ -1262,7 +1262,7 @@ actions.undelegate = async (payload) => {
                 api.emit('undelegateStart', {
                   from: nftInstance.delegatedTo.account, fromType: nftInstance.delegatedTo.ownedBy, symbol, id,
                 });
-                await api.executeSmartContract('mining', 'handleNftChange', { symbol, nft: nftInstance, add: false });
+                await api.executeSmartContract('mining', 'handleNftDelegationChange', { symbol, nft: nftInstance, add: false });
               }
             }
           }

--- a/test/mining.js
+++ b/test/mining.js
@@ -1623,6 +1623,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "mining", "toType": "contract", "nfts": [ {"symbol":"TSTNFT", "ids": ["2"]} ] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'undelegate', '{ "nfts": [ {"symbol": "TSTNFT", "ids": ["2"]} ], "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 720, "lotteryAmount": "1", "minedToken": "TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bull": ["2.0", "1.5"], "bear": ["-1.0", "0.9"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}]}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'setActive', '{ "id": "TKN::TSTNFT", "active": true, "isSignedWithActiveKey": false }'));
 
       let block = {
         refHiveBlockNumber: refBlockNumber,

--- a/test/mining.js
+++ b/test/mining.js
@@ -128,6 +128,21 @@ async function assertNftTokenPool(symbol, poolId) {
   assert.ok(res, `NFT Token pool ${poolId} not found for ${symbol}.`);
 }
 
+async function assertNoNftTokenPool(symbol, poolId) {
+  let res = await fixture.database.findOne({
+      contract: 'mining',
+      table: 'nftTokenPools',
+      query: {
+        symbol,
+        id: poolId,
+      }
+    });
+
+  assert.ok(!res, `NFT Token pool ${poolId} found but not expected for ${symbol}.`);
+}
+
+
+
 async function assertTotalStaked(amount, symbol='TKN') {
     let res = await fixture.database.findOne({
         contract: 'tokens',
@@ -1559,15 +1574,15 @@ describe('mining', function () {
       let txs = res.transactions;
 
       await assertPool({id: 'TEST-TKN::TSTNFT', totalPower: '0'});
-      await assertNftTokenPool('TSTNFT', 'TEST-TKN::TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TEST-TKN::TSTNFT');
       await assertPool({id: 'TEST-TKN:TEST-TKN:TSTNFT', totalPower: '0'});
-      await assertNftTokenPool('TSTNFT', 'TEST-TKN:TEST-TKN:TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TEST-TKN:TEST-TKN:TSTNFT');
       await assertPool({id: 'TKNB:TEST-TKN:TSTNFT', totalPower: '0'});
-      await assertNftTokenPool('TSTNFT', 'TKNB:TEST-TKN:TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TKNB:TEST-TKN:TSTNFT');
       await assertPool({id: 'TKNC:TEST-TKN:TSTNFT', totalPower: '0'});
-      await assertNftTokenPool('TSTNFT', 'TKNC:TEST-TKN:TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TKNC:TEST-TKN:TSTNFT');
       await assertPool({id: 'TKND:TEST-TKN:TSTNFT', totalPower: '0'});
-      await assertNftTokenPool('TSTNFT', 'TKND:TEST-TKN:TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TKND:TEST-TKN:TSTNFT');
 
       let eventLog = JSON.parse(res.transactions[0].logs);
       let createPoolEvent = eventLog.events.find(x => x.event === 'createPool');
@@ -1588,6 +1603,91 @@ describe('mining', function () {
       eventLog = JSON.parse(res.transactions[4].logs);
       createPoolEvent = eventLog.events.find(x => x.event === 'createPool');
       assert.equal(createPoolEvent.data.id, 'TKND:TEST-TKN:TSTNFT');
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+
+  });
+
+  it('should only allow two active nft miners per nft token', (done) => {
+    new Promise(async (resolve) => {
+      await fixture.setUp();
+
+      let refBlockNumber = fixture.getNextRefBlockNumber();
+      let transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(tokenfundsContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(nftContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(contractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to": "harpagon", "quantity": "2100", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "symbol": "TEST.TKN", "precision": 8, "maxSupply": "1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "symbol": "TKNB", "precision": 8, "maxSupply": "1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "symbol": "TKNC", "precision": 8, "maxSupply": "1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "symbol": "TKND", "precision": 8, "maxSupply": "1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'enableStaking', '{ "symbol": "TEST.TKN", "unstakingCooldown": 7, "numberTransactions": 1, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'enableDelegation', '{ "symbol": "TEST.TKN", "undelegationCooldown": 7, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'updateParams', '{ "poolCreationFee": "0" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'updateParams', '{ "nftCreationFee": "0", "enableDelegationFee": "0", "dataPropertyCreationFee": "0", "nftIssuanceFee": {} }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'create', '{ "isSignedWithActiveKey":true, "name":"test NFT", "symbol":"TSTNFT", "url":"http://mynft.com", "maxSupply":"1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'enableDelegation', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFT", "undelegationCooldown": 1 }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'addProperty', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFT", "name":"type", "type":"string", "isReadOnly":false }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'addProperty', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFT", "name":"equip", "type":"string", "isReadOnly":false }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'addProperty', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFT", "name":"miningPower", "type":"string", "isReadOnly":false }'));
+      
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+      await tableAsserts.assertNoErrorInLastBlock();
+      
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 1, "lotteryAmount": "1", "minedToken": "TEST.TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bear": ["-1.0", "2.0"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}]}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 1, "lotteryAmount": "1", "minedToken": "TEST.TKN", "tokenMiners": [{"symbol": "TEST.TKN", "multiplier": 1}], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bear": ["-1.0", "2.0"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}]}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 1, "lotteryAmount": "1", "minedToken": "TKNB", "tokenMiners": [{"symbol": "TEST.TKN", "multiplier": 1}], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bear": ["-1.0", "2.0"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "equipField": "equip"}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 1, "lotteryAmount": "1", "minedToken": "TKNC", "tokenMiners": [{"symbol": "TEST.TKN", "multiplier": 1}], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bear": ["-1.0", "2.0"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "miningPowerField": "miningPower"}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 1, "lotteryAmount": "1", "minedToken": "TKND", "tokenMiners": [{"symbol": "TEST.TKN", "multiplier": 1}], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bear": ["-1.0", "2.0"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "equipField": "equip", "miningPowerField": "miningPower"}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'setActive', '{ "id": "TEST-TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'setActive', '{ "id": "TEST-TKN:TEST-TKN:TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'setActive', '{ "id": "TKNB:TEST-TKN:TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'setActive', '{ "id": "TKNC:TEST-TKN:TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'setActive', '{ "id": "TKND:TEST-TKN:TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+
+      let res = await fixture.database.getLatestBlockInfo();
+      let txs = res.transactions;
+
+      await assertPool({id: 'TEST-TKN::TSTNFT', totalPower: '0'});
+      await assertNftTokenPool('TSTNFT', 'TEST-TKN::TSTNFT');
+      await assertPool({id: 'TEST-TKN:TEST-TKN:TSTNFT', totalPower: '0'});
+      await assertNftTokenPool('TSTNFT', 'TEST-TKN:TEST-TKN:TSTNFT');
+      await assertPool({id: 'TKNB:TEST-TKN:TSTNFT', totalPower: '0'});
+      await assertNoNftTokenPool('TSTNFT', 'TKNB:TEST-TKN:TSTNFT');
+      assertError(txs[7], 'can have at most 2 active nft token pools for nft token');
+      await assertPool({id: 'TKNC:TEST-TKN:TSTNFT', totalPower: '0'});
+      await assertNoNftTokenPool('TSTNFT', 'TKNC:TEST-TKN:TSTNFT');
+      assertError(txs[8], 'can have at most 2 active nft token pools for nft token');
+      await assertPool({id: 'TKND:TEST-TKN:TSTNFT', totalPower: '0'});
+      await assertNoNftTokenPool('TSTNFT', 'TKND:TEST-TKN:TSTNFT');
+      assertError(txs[9], 'can have at most 2 active nft token pools for nft token');
 
       resolve();
     })
@@ -2778,9 +2878,9 @@ describe('mining', function () {
       await tableAsserts.assertNoErrorInLastBlock();
 
       await assertPool({id: 'TESTTKN::TSTNFT', totalPower: '0'});
-      await assertNftTokenPool('TSTNFT', 'TESTTKN::TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TESTTKN::TSTNFT');
       await assertPool({id: 'TESTTKN:TESTTKN:TSTNFT', totalPower: '0'});
-      await assertNftTokenPool('TSTNFT', 'TESTTKN:TESTTKN:TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TESTTKN:TESTTKN:TSTNFT');
 
       refBlockNumber = fixture.getNextRefBlockNumber();
       transactions = [];
@@ -2883,8 +2983,8 @@ describe('mining', function () {
 
       await tableAsserts.assertNoErrorInLastBlock();
 
-      await assertNftTokenPool('TSTNFT', 'TEST-TKN::TSTNFT');
-      await assertNftTokenPool('TSTNFT', 'TEST-TKN:TEST-TKN:TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TEST-TKN::TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TEST-TKN:TEST-TKN:TSTNFT');
       await assertTokenPool('TEST.TKN', 'TEST-TKN:TEST-TKN:TSTNFT');
 
       await assertNftInstance('satoshi', 'TSTNFT', 1, {'account': 'mining', 'ownedBy': 'c'});
@@ -3441,7 +3541,7 @@ describe('mining', function () {
 
       await tableAsserts.assertNoErrorInLastBlock();
 
-      await assertNftTokenPool('TSTNFT', 'TEST-TKN:TEST-TKN:TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TEST-TKN:TEST-TKN:TSTNFT');
       await assertTokenPool('TEST.TKN', 'TEST-TKN:TEST-TKN:TSTNFT');
 
       await assertNftInstance('satoshi', 'TSTNFT', 1, {'account': 'mining', 'ownedBy': 'c'});
@@ -3548,7 +3648,7 @@ describe('mining', function () {
 
       await tableAsserts.assertNoErrorInLastBlock();
 
-      await assertNftTokenPool('TSTNFT', 'TESTTKN:TESTTKN:TSTNFT');
+      await assertNoNftTokenPool('TSTNFT', 'TESTTKN:TESTTKN:TSTNFT');
       await assertTokenPool('TESTTKN', 'TESTTKN:TESTTKN:TSTNFT');
 
       await assertNftInstance('satoshi', 'TSTNFT', 1, {'account': 'mining', 'ownedBy': 'c'});

--- a/test/mining.js
+++ b/test/mining.js
@@ -1623,7 +1623,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "mining", "toType": "contract", "nfts": [ {"symbol":"TSTNFT", "ids": ["2"]} ] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'undelegate', '{ "nfts": [ {"symbol": "TSTNFT", "ids": ["2"]} ], "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 720, "lotteryAmount": "1", "minedToken": "TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bull": ["2.0", "1.5"], "bear": ["-1.0", "0.9"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}]}, "isSignedWithActiveKey": true }'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'setActive', '{ "id": "TKN::TSTNFT", "active": true, "isSignedWithActiveKey": false }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'setActive', '{ "id": "TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
 
       let block = {
         refHiveBlockNumber: refBlockNumber,
@@ -1808,6 +1808,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "mining", "toType": "contract", "nfts": [ {"symbol":"TSTNFT", "ids": ["2"]} ] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'undelegate', '{ "nfts": [ {"symbol": "TSTNFT", "ids": ["2"]} ], "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 720, "lotteryAmount": "1", "minedToken": "TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bull": ["2.0", "1.5"], "bear": ["-1.0", "0.9"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "equipField": "equip"}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'setActive', '{ "id": "TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
 
       let block = {
         refHiveBlockNumber: refBlockNumber,
@@ -1990,6 +1991,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "harpagon", "toType": "user", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"type": "bull"}}`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 720, "lotteryAmount": "1", "minedToken": "TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bull": ["2.0", "1.5"], "bear": ["-1.0", "0.9"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "equipField": "equip"}, "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'nft', 'setProperties', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "nfts": [ { "id": "1", "properties": { "equip": "satoshi"}}]}`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'setActive', '{ "id": "TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
 
       let block = {
         refHiveBlockNumber: refBlockNumber,
@@ -2244,6 +2246,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "mining", "toType": "contract", "nfts": [ {"symbol":"TSTNFT", "ids": ["2"]} ] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'undelegate', '{ "nfts": [ {"symbol": "TSTNFT", "ids": ["2"]} ], "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 720, "lotteryAmount": "1", "minedToken": "TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bull": ["2.0", "1.5"], "bear": ["-1.0", "0.9"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "miningPowerField": "miningPower"}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'setActive', '{ "id": "TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'nft', 'setProperties', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "nfts": [ { "id": "2", "properties": { "miningPower": "1000" }}]}`));
 
       let block = {
@@ -2431,6 +2434,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "mining", "toType": "contract", "nfts": [ {"symbol":"TSTNFT", "ids": ["2"]} ] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'undelegate', '{ "nfts": [ {"symbol": "TSTNFT", "ids": ["2"]} ], "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 720, "lotteryAmount": "1", "minedToken": "TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "miningPowerField": "miningPower"}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'setActive', '{ "id": "TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'nft', 'setProperties', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "nfts": [ { "id": "2", "properties": { "miningPower": "1000" }}]}`));
 
       let block = {
@@ -2616,6 +2620,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"type": "bull"}}`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"type": "bull"}}`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 720, "lotteryAmount": "1", "minedToken": "TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bull": ["2.0", "1.5"], "bear": ["-1.0", "0.9"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "equipField": "equip", "miningPowerField": "miningPower"}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'mining', 'setActive', '{ "id": "TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'nft', 'setProperties', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "nfts": [ { "id": "1", "properties": { "equip": "satoshi" }}]}`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'harpagon', 'nft', 'setProperties', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "nfts": [ { "id": "2", "properties": { "miningPower": "1000" }}]}`));
 
@@ -2995,6 +3000,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', '{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "bear"}}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', '{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "bull"}}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 1, "lotteryAmount": "1", "minedToken": "TEST.TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bear": ["-1.0", "0.5"], "bull": ["2.0", "1.5"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}]}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'setActive', '{ "id": "TEST-TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "mining", "toType": "contract", "nfts": [ {"symbol":"TSTNFT", "ids": ["1"]} ] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi2', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "satoshi", "toType": "user", "nfts": [ {"symbol":"TSTNFT", "ids": ["2"]} ] }'));
 
@@ -3134,6 +3140,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', '{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "bear", "miningPower": "100000"}}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', '{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "bull", "miningPower": "1000000"}}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 1, "lotteryAmount": "1", "minedToken": "TEST.TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bear": ["-1.0", "0.5"], "bull": ["2.0", "1.5"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "miningPowerField": "miningPower"}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'setActive', '{ "id": "TEST-TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "mining", "toType": "contract", "nfts": [ {"symbol":"TSTNFT", "ids": ["1"]} ] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi2', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "satoshi", "toType": "user", "nfts": [ {"symbol":"TSTNFT", "ids": ["2"]} ] }'));
 
@@ -3278,6 +3285,7 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', '{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "bear", "miningPower": "100000"}}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', '{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "bull", "miningPower": "1000000"}}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 1, "lotteryAmount": "1", "minedToken": "TEST.TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bear": ["-1.0", "0.5"], "bull": ["2.0", "1.5"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}], "equipField": "equip", "miningPowerField": "miningPower"}, "isSignedWithActiveKey": true }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'setActive', '{ "id": "TEST-TKN::TSTNFT", "active": true, "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'setProperties', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "nfts": [ { "id": "1", "properties": { "equip": "satoshi" }}]}`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'setProperties', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "nfts": [ { "id": "2", "properties": { "equip": "satoshi" }}]}`));
 


### PR DESCRIPTION
Restore update functionality, and skip inactive pools .

Note that if a pool is inactive, to reactivate the pool owner should change a setting to recompute mining power right before so any nft changes since deactivation can be computed again. This can be a mining setting or a burn change action.

To deploy: first deploy mining, followed by nft.