### PR TITLE
fix issue where non-typemap equipped nfts do not reset balance on update

### DIFF
--- a/contracts/mining.js
+++ b/contracts/mining.js
@@ -375,16 +375,18 @@ async function updateNftMiningPower(pool, nft, add, updatePoolTimestamp, account
     const nftBalances = {};
     const equippedNft = { type: nftType };
 
-    if (typeProperties) {
-      for (let i = 0; i < properties.length; i += 1) {
-        const property = properties[i];
-        const opInfo = PROPERTY_OPS[property.op];
-        if (add) {
+    for (let i = 0; i < properties.length; i += 1) {
+      const property = properties[i];
+      const opInfo = PROPERTY_OPS[property.op];
+      if (add) {
+        if (typeProperties) {
           nftBalances[i] = opInfo.add(opInfo.defaultValue, typeProperties[i]);
         } else {
-          api.assert(false, 'unexpected condition: remove without previous miningPower');
-          return api.BigNumber(0);
+          nftBalances[i] = opInfo.defaultValue;
         }
+      } else {
+        api.assert(false, 'unexpected condition: remove without previous miningPower');
+        return api.BigNumber(0);
       }
     }
     if (miningPowerField) {
@@ -422,13 +424,11 @@ async function updateNftMiningPower(pool, nft, add, updatePoolTimestamp, account
       miningPower.equippedNfts[nft._id] = equippedNft;
     }
     const { nftBalances } = miningPower;
-    if (typeProperties) {
-      for (let i = 0; i < properties.length; i += 1) {
-        const property = properties[i];
-        const opInfo = PROPERTY_OPS[property.op];
-        if (!nftBalances[i] || miningPower.updatePoolTimestamp !== updatePoolTimestamp) {
-          nftBalances[i] = opInfo.defaultValue;
-        }
+    for (let i = 0; i < properties.length; i += 1) {
+      const property = properties[i];
+      const opInfo = PROPERTY_OPS[property.op];
+      if (!nftBalances[i] || miningPower.updatePoolTimestamp !== updatePoolTimestamp) {
+        nftBalances[i] = opInfo.defaultValue;
       }
     }
     if (miningPowerField && miningPower.updatePoolTimestamp !== updatePoolTimestamp) {

--- a/test/mining.js
+++ b/test/mining.js
@@ -2554,7 +2554,7 @@ describe('mining', function () {
       await assertNftInstance('satoshi', 'TSTNFT', 1, {'account': 'mining', 'ownedBy': 'c'});
       await assertNftInstance('satoshi', 'TSTNFT', 2, {'account': 'mining', 'ownedBy': 'c', 'undelegateAt': 1527897600000});
 
-      await assertMiningPower('satoshi', 'TKN::TSTNFT', '0', {'_miningPower': '0'});
+      await assertMiningPower('satoshi', 'TKN::TSTNFT', '0', {'0': 0, '1': 1, '_miningPower': '0'});
       await assertPool({id: 'TKN::TSTNFT', totalPower: '0'});
 
       refBlockNumber = fixture.getNextRefBlockNumber();
@@ -2577,7 +2577,7 @@ describe('mining', function () {
 
       await assertNftInstance('satoshi', 'TSTNFT', 3, {'account': 'mining', 'ownedBy': 'c'});
 
-      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {'_miningPower': '10000'}, {"1":{"type":"bull","extraMiningPower":"0"},"3":{"type":"bear","extraMiningPower":"10000"}});
+      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {"0":0,"1":1,"_miningPower":"10000"}, {"1":{"type":"bull","extraMiningPower":"0"},"3":{"type":"bear","extraMiningPower":"10000"}});
       await assertPool({id: 'TKN::TSTNFT', totalPower: '10000'});
 
       refBlockNumber = fixture.getNextRefBlockNumber();
@@ -2600,7 +2600,7 @@ describe('mining', function () {
 
       await assertNftInstance('satoshi2', 'TSTNFT', 4, {'account': 'satoshi', 'ownedBy': 'u'});
 
-      await assertMiningPower('satoshi', 'TKN::TSTNFT', '110000', {'_miningPower': '110000'});
+      await assertMiningPower('satoshi', 'TKN::TSTNFT', '110000', {"0":0,"1":1,"_miningPower":"110000"});
       await assertMiningPower('satoshi2', 'TKN::TSTNFT', null);
       await assertPool({id: 'TKN::TSTNFT', totalPower: '110000'});
 
@@ -2622,7 +2622,7 @@ describe('mining', function () {
 
       await assertNftInstance('satoshi2', 'TSTNFT', 4, {'account': 'satoshi', 'ownedBy': 'u', "undelegateAt":1527897600000});
 
-      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {'_miningPower': '10000'});
+      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {"0":0,"1":1,"_miningPower":"10000"});
       await assertMiningPower('satoshi2', 'TKN::TSTNFT', null);
       await assertPool({id: 'TKN::TSTNFT', totalPower: '10000'});
 
@@ -2642,7 +2642,7 @@ describe('mining', function () {
 
       await assertNftInstance('satoshi2', 'TSTNFT', 4, undefined);
 
-      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {'_miningPower': '10000'});
+      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {"0":0,"1":1,"_miningPower":"10000"});
       await assertMiningPower('satoshi2', 'TKN::TSTNFT', null);
       await assertPool({id: 'TKN::TSTNFT', totalPower: '10000'});
 
@@ -2664,7 +2664,7 @@ describe('mining', function () {
 
       await assertNftInstance('satoshi', 'TSTNFT', 1, {"account":"mining","ownedBy":"c","undelegateAt":1527984000000});
 
-      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {'_miningPower': '10000'});
+      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {"0":0,"1":1,'_miningPower': '10000'});
       await assertMiningPower('satoshi2', 'TKN::TSTNFT', null);
       await assertPool({id: 'TKN::TSTNFT', totalPower: '10000'});
 
@@ -2684,7 +2684,7 @@ describe('mining', function () {
 
       await assertNftInstance('satoshi', 'TSTNFT', 1, undefined);
 
-      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {'_miningPower': '10000'});
+      await assertMiningPower('satoshi', 'TKN::TSTNFT', '10000', {"0":0,"1":1,'_miningPower': '10000'});
       await assertMiningPower('satoshi2', 'TKN::TSTNFT', null);
       await assertPool({id: 'TKN::TSTNFT', totalPower: '10000'});
 

--- a/test/mining.js
+++ b/test/mining.js
@@ -2962,10 +2962,12 @@ describe('mining', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'create', '{ "isSignedWithActiveKey":true, "name":"test NFT", "symbol":"TSTNFT", "url":"http://mynft.com", "maxSupply":"1000" }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'enableDelegation', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFT", "undelegationCooldown": 1 }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'addProperty', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFT", "name":"type", "type":"string", "isReadOnly":false }'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', '{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "bull"}}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', '{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "other"}}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "mining", "toType": "contract", "nfts": [ {"symbol":"TSTNFT", "ids": ["1"]} ] }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', '{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "bull"}}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "mining", "toType": "contract", "nfts": [ {"symbol":"TSTNFT", "ids": ["2"]} ] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "to": "satoshi2", "toType": "user", "feeSymbol": "TEST.TKN", "properties": {"type": "bear"}}`));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi2', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "satoshi", "toType": "user", "nfts": [ {"symbol":"TSTNFT", "ids": ["2"]} ] }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi2', 'nft', 'delegate', '{ "isSignedWithActiveKey":true, "to": "satoshi", "toType": "user", "nfts": [ {"symbol":"TSTNFT", "ids": ["3"]} ] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'issue', '{ "symbol": "TEST.TKN", "quantity": "100", "to": "satoshi", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'satoshi', 'tokens', 'stake', '{ "to":"satoshi", "to":"satoshi", "symbol": "TEST.TKN", "quantity": "50", "isSignedWithActiveKey": true }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'mining', 'createPool', '{ "lotteryWinners": 1, "lotteryIntervalHours": 1, "lotteryAmount": "1", "minedToken": "TEST.TKN", "tokenMiners": [], "nftTokenMiner": {"symbol": "TSTNFT", "typeField": "type", "typeMap": {"bear": ["-1.0", "0.5"], "bull": ["2.0", "1.5"]}, "properties": [{"op": "ADD", "name": "power"}, {"op": "MULTIPLY", "name": "boost"}]}, "isSignedWithActiveKey": true }'));
@@ -2988,7 +2990,8 @@ describe('mining', function () {
       await assertTokenPool('TEST.TKN', 'TEST-TKN:TEST-TKN:TSTNFT');
 
       await assertNftInstance('satoshi', 'TSTNFT', 1, {'account': 'mining', 'ownedBy': 'c'});
-      await assertNftInstance('satoshi2', 'TSTNFT', 2, {'account': 'satoshi', 'ownedBy': 'u'});
+      await assertNftInstance('satoshi', 'TSTNFT', 2, {'account': 'mining', 'ownedBy': 'c'});
+      await assertNftInstance('satoshi2', 'TSTNFT', 3, {'account': 'satoshi', 'ownedBy': 'u'});
       await tableAsserts.assertUserBalances({ account: 'satoshi', symbol: 'TEST.TKN', balance: '50.00000000', stake: '50.00000000' });
 
       await assertMiningPower('satoshi', 'TEST-TKN::TSTNFT', '0.75', {0: '1', 1: '0.75'});


### PR DESCRIPTION
When an equipped nft is not in the type map, when we recompute balances, it fails to reset the nftBalances field.

Eventually, we should not need to do this anymore as we started to track equipped nft's and types directly in the miningpower object. This will make the update a lot faster as well. Needs subsequent fix.