### PR TITLE
Add extra validation for marketAccount and officialMarket settings

### DIFF
--- a/contracts/nftmarket.js
+++ b/contracts/nftmarket.js
@@ -521,7 +521,8 @@ actions.buy = async (payload) => {
     && isValidIdArray(nfts)
     && api.assert(tableExists, 'market not enabled for symbol')) {
     const finalMarketAccount = marketAccount.trim().toLowerCase();
-    if (api.assert(isValidHiveAccountLength(finalMarketAccount), 'invalid market account')) {
+    if (api.assert(isValidHiveAccountLength(finalMarketAccount), 'invalid market account')
+      && api.assert(finalMarketAccount !== api.sender, 'market account cannot be same as buyer')) {
       const nft = await api.db.findOneInTable('nft', 'nfts', { symbol });
       if (!api.assert(nft && nft.groupBy && nft.groupBy.length > 0, 'market grouping not set')) {
         return;
@@ -601,8 +602,13 @@ actions.buy = async (payload) => {
           sellerMap[key] = sellerInfo;
         }
 
-        // check if we have to split the fee into market & agent fees
         const params = await api.db.findOne('params', { symbol });
+        const officialMarketAccount = (params && params.officialMarket) ? params.officialMarket : finalMarketAccount;
+        if (!api.assert(officialMarketAccount !== api.sender, 'official market account cannot be same as buyer')) {
+          return;
+        }
+
+        // check if we have to split the fee into market & agent fees
         if (params && params.officialMarket && params.agentCut !== undefined && params.agentCut > 0 && feeTotal.gt(0)) {
           const agentFeePercent = params.agentCut / 10000;
           agentFeeTotal = feeTotal.multipliedBy(agentFeePercent).decimalPlaces(token.precision);
@@ -628,7 +634,6 @@ actions.buy = async (payload) => {
         paymentTotal = paymentTotal.toFixed(token.precision);
 
         // send fee to market account
-        const officialMarketAccount = (params && params.officialMarket) ? params.officialMarket : finalMarketAccount;
         let isMarketFeePaid = false;
         if (feeTotal.gt(0)) {
           isMarketFeePaid = true;

--- a/test/nftmarket.js
+++ b/test/nftmarket.js
@@ -668,6 +668,7 @@ describe('nftmarket', function() {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(nftmarketContractPayload)));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nft', 'updateParams', `{ "nftCreationFee": "5", "nftIssuanceFee": {"${CONSTANTS.UTILITY_TOKEN_SYMBOL}":"0.1"}, "dataPropertyCreationFee": "1" }`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol":"${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to":"cryptomancer", "quantity":"200", "isSignedWithActiveKey":true }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol":"${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to":"mancermart", "quantity":"200", "isSignedWithActiveKey":true }`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol":"${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to":"yabapmatt", "quantity":"3.14158999", "isSignedWithActiveKey":true }`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'create', '{ "isSignedWithActiveKey": true,  "name": "token", "url": "https://token.com", "symbol": "TKN", "precision": 3, "maxSupply": "1000", "isSignedWithActiveKey": true  }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'cryptomancer', 'nft', 'create', '{ "isSignedWithActiveKey": true, "name":"test NFT", "symbol":"TEST", "url":"http://mynft.com" }'));
@@ -679,6 +680,7 @@ describe('nftmarket', function() {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'cryptomancer', 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "to":"aggroed", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}" }`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'cryptomancer', 'nft', 'issue', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "to":"marc", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}" }`));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'cryptomancer', 'nftmarket', 'enableMarket', '{ "isSignedWithActiveKey": true, "symbol": "TEST" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'cryptomancer', 'nftmarket', 'setMarketParams', '{ "isSignedWithActiveKey": true, "symbol": "TEST", "officialMarket": "mancermart", "agentCut": 2000 }'));
 
       // do a few sell orders
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'aggroed', 'nftmarket', 'sell', `{ "isSignedWithActiveKey": true, "symbol": "TEST", "nfts": ["1","2","3"], "price": "3.14159", "priceSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "fee": 500 }`));
@@ -696,6 +698,8 @@ describe('nftmarket', function() {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'cryptomancer', 'nftmarket', 'buy', '{ "isSignedWithActiveKey": true, "marketAccount": "peakmonsters", "symbol": "TEST", "nfts": ["1","2","3","4","5","6","7","8","9","10","11","12","13","14","15","16","17","18","19","20","21","22","23","24","25","26","27","28","29","30","31","32","33","34","35","36","37","38","39","40","41","42","43","44","45","46","47","48","49","50","51"] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'cryptomancer', 'nftmarket', 'buy', '{ "isSignedWithActiveKey": true, "expPriceSymbol": "ENG", "marketAccount": "peakmonsters", "symbol": "TEST", "nfts": ["1","2","3"] }'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'cryptomancer', 'nftmarket', 'buy', `{ "isSignedWithActiveKey": true, "expPriceSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "expPrice": "9.42477001", "marketAccount": "peakmonsters", "symbol": "TEST", "nfts": ["1","2","3"] }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'cryptomancer', 'nftmarket', 'buy', '{ "isSignedWithActiveKey": true, "marketAccount": "cryptomancer", "symbol": "TEST", "nfts": ["1"] }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'mancermart', 'nftmarket', 'buy', '{ "isSignedWithActiveKey": true, "marketAccount": "cryptomancer", "symbol": "TEST", "nfts": ["1"] }'));
 
       let block = {
         refHiveBlockNumber: refBlockNumber,
@@ -711,8 +715,6 @@ describe('nftmarket', function() {
 
       const block1 = res;
       const transactionsBlock1 = block1.transactions;
-      console.log(JSON.parse(transactionsBlock1[18].logs).errors[0]);
-      console.log(JSON.parse(transactionsBlock1[19].logs).errors[0]);
       console.log(JSON.parse(transactionsBlock1[20].logs).errors[0]);
       console.log(JSON.parse(transactionsBlock1[21].logs).errors[0]);
       console.log(JSON.parse(transactionsBlock1[22].logs).errors[0]);
@@ -722,18 +724,24 @@ describe('nftmarket', function() {
       console.log(JSON.parse(transactionsBlock1[26].logs).errors[0]);
       console.log(JSON.parse(transactionsBlock1[27].logs).errors[0]);
       console.log(JSON.parse(transactionsBlock1[28].logs).errors[0]);
+      console.log(JSON.parse(transactionsBlock1[29].logs).errors[0]);
+      console.log(JSON.parse(transactionsBlock1[30].logs).errors[0]);
+      console.log(JSON.parse(transactionsBlock1[31].logs).errors[0]);
+      console.log(JSON.parse(transactionsBlock1[32].logs).errors[0]);
 
-      assert.equal(JSON.parse(transactionsBlock1[18].logs).errors[0], 'market not enabled for symbol');
-      assert.equal(JSON.parse(transactionsBlock1[19].logs).errors[0], 'you must use a custom_json signed with your active key');
-      assert.equal(JSON.parse(transactionsBlock1[20].logs).errors[0], 'invalid params');
-      assert.equal(JSON.parse(transactionsBlock1[21].logs).errors[0], 'invalid params');
-      assert.equal(JSON.parse(transactionsBlock1[22].logs).errors[0], 'invalid market account');
-      assert.equal(JSON.parse(transactionsBlock1[23].logs).errors[0], 'cannot fill your own orders');
-      assert.equal(JSON.parse(transactionsBlock1[24].logs).errors[0], 'all orders must have the same price symbol');
-      assert.equal(JSON.parse(transactionsBlock1[25].logs).errors[0], 'you must have enough tokens for payment');
-      assert.equal(JSON.parse(transactionsBlock1[26].logs).errors[0], 'cannot act on more than 50 IDs at once');
-      assert.equal(JSON.parse(transactionsBlock1[27].logs).errors[0], 'unexpected price symbol BEE');
-      assert.equal(JSON.parse(transactionsBlock1[28].logs).errors[0], 'total required payment 9.42477000 BEE does not match expected amount');
+      assert.equal(JSON.parse(transactionsBlock1[20].logs).errors[0], 'market not enabled for symbol');
+      assert.equal(JSON.parse(transactionsBlock1[21].logs).errors[0], 'you must use a custom_json signed with your active key');
+      assert.equal(JSON.parse(transactionsBlock1[22].logs).errors[0], 'invalid params');
+      assert.equal(JSON.parse(transactionsBlock1[23].logs).errors[0], 'invalid params');
+      assert.equal(JSON.parse(transactionsBlock1[24].logs).errors[0], 'invalid market account');
+      assert.equal(JSON.parse(transactionsBlock1[25].logs).errors[0], 'cannot fill your own orders');
+      assert.equal(JSON.parse(transactionsBlock1[26].logs).errors[0], 'all orders must have the same price symbol');
+      assert.equal(JSON.parse(transactionsBlock1[27].logs).errors[0], 'you must have enough tokens for payment');
+      assert.equal(JSON.parse(transactionsBlock1[28].logs).errors[0], 'cannot act on more than 50 IDs at once');
+      assert.equal(JSON.parse(transactionsBlock1[29].logs).errors[0], 'unexpected price symbol BEE');
+      assert.equal(JSON.parse(transactionsBlock1[30].logs).errors[0], 'total required payment 9.42477000 BEE does not match expected amount');
+      assert.equal(JSON.parse(transactionsBlock1[31].logs).errors[0], 'market account cannot be same as buyer');
+      assert.equal(JSON.parse(transactionsBlock1[32].logs).errors[0], 'official market account cannot be same as buyer');
 
       // check if the NFT instances are still owned by the market
       let instances = await fixture.database.find({


### PR DESCRIPTION
This is to prevent an error that can happen if a buyer tries to set itself as the market account to receive fees from NFT purchases.  Here's an example of one such invalid transaction:

https://he.dtools.dev/tx/63002c925da6f3a585f531bec353d45359c84f69

The solution is to disallow cases where the buyer account is the same as the marketAccount parameter or the officialMarket setting of the market.