### PR TITLE
Reduce fees for HIVE deposits & withdrawals from 1% to 0.75%

### DIFF
--- a/contracts/hivepegged.js
+++ b/contracts/hivepegged.js
@@ -35,8 +35,8 @@ actions.buy = async (payload) => {
     if (api.assert(unit === 'HIVE', 'only HIVE can be used')) {
       let quantityToSend = res[0];
 
-      // calculate the 1% fee (with a min of 0.001 HIVE)
-      let fee = api.BigNumber(quantityToSend).multipliedBy(0.01).toFixed(3);
+      // calculate the 0.75% fee (with a min of 0.001 HIVE)
+      let fee = api.BigNumber(quantityToSend).multipliedBy('0.0075').toFixed(3);
 
       if (api.BigNumber(fee).lt('0.001')) {
         fee = '0.001';
@@ -67,8 +67,8 @@ actions.withdraw = async (payload) => {
     && api.BigNumber(quantity).dp() <= 3, 'invalid params')
     && api.assert(api.BigNumber(quantity).gte(0.002), 'minimum withdrawal is 0.002')
   ) {
-    // calculate the 1% fee (with a min of 0.001 HIVE)
-    let fee = api.BigNumber(quantity).multipliedBy(0.01).toFixed(3);
+    // calculate the 0.75% fee (with a min of 0.001 HIVE)
+    let fee = api.BigNumber(quantity).multipliedBy('0.0075').toFixed(3);
 
     if (api.BigNumber(fee).lt('0.001')) {
       fee = '0.001';

--- a/libs/util/contractUtil.js
+++ b/libs/util/contractUtil.js
@@ -12,6 +12,7 @@ function setupContractPayload(name, file, additionalReplacements = null) {
   contractCode = contractCode.replace(/'\$\{CONSTANTS.GOVERNANCE_TOKEN_MIN_VALUE\}\$'/g, CONSTANTS.GOVERNANCE_TOKEN_MIN_VALUE);
   contractCode = contractCode.replace(/'\$\{CONSTANTS.HIVE_PEGGED_SYMBOL\}\$'/g, CONSTANTS.HIVE_PEGGED_SYMBOL);
   contractCode = contractCode.replace(/'\$\{CONSTANTS.HIVE_ENGINE_ACCOUNT\}\$'/g, CONSTANTS.HIVE_ENGINE_ACCOUNT);
+  contractCode = contractCode.replace(/'\$\{CONSTANTS.ACCOUNT_RECEIVING_FEES\}\$'/g, CONSTANTS.ACCOUNT_RECEIVING_FEES);
   if (additionalReplacements) {
     contractCode = additionalReplacements(contractCode);
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test15": "./node_modules/mocha/bin/mocha ./test/tokenfunds.js",
     "test16": "./node_modules/mocha/bin/mocha ./test/nftauction.js",
     "test17": "./node_modules/mocha/bin/mocha ./test/comments.js",
-    "test18": "./node_modules/mocha/bin/mocha ./test/ticks.js"
+    "test18": "./node_modules/mocha/bin/mocha ./test/ticks.js",
+    "test19": "./node_modules/mocha/bin/mocha ./test/hivepegged.js"
   },
   "engines": {
     "node": ">=13.7.0",

--- a/test/hivepegged.js
+++ b/test/hivepegged.js
@@ -101,7 +101,7 @@ describe('Hive Pegged', function () {
       assert.equal(balances[0].account, 'harpagon');
       assert.equal(balances[0].symbol, CONSTANTS.HIVE_PEGGED_SYMBOL);
 
-      assert.equal(balances[1].balance, 0.87);
+      assert.equal(balances[1].balance, 0.872);
       assert.equal(balances[1].account, 'satoshi');
       assert.equal(balances[1].symbol, CONSTANTS.HIVE_PEGGED_SYMBOL);
 
@@ -154,7 +154,7 @@ describe('Hive Pegged', function () {
       assert.equal(balances[0].account, 'harpagon');
       assert.equal(balances[0].symbol, CONSTANTS.HIVE_PEGGED_SYMBOL);
 
-      assert.equal(balances[1].balance, 0.57);
+      assert.equal(balances[1].balance, 0.572);
       assert.equal(balances[1].account, 'satoshi');
       assert.equal(balances[1].symbol, CONSTANTS.HIVE_PEGGED_SYMBOL);
 
@@ -177,7 +177,7 @@ describe('Hive Pegged', function () {
       assert.equal(withdrawals[1].type, 'HIVE');
       assert.equal(withdrawals[1].recipient, CONSTANTS.HIVE_ENGINE_ACCOUNT);
       assert.equal(withdrawals[1].memo, 'fee tx TXID00000005');
-      assert.equal(withdrawals[1].quantity, 0.009);
+      assert.equal(withdrawals[1].quantity, 0.007);
 
       assert.equal(withdrawals[2].id, 'TXID00000006');
       assert.equal(withdrawals[2].type, 'HIVE');
@@ -195,13 +195,13 @@ describe('Hive Pegged', function () {
       assert.equal(withdrawals[4].type, 'HIVE');
       assert.equal(withdrawals[4].recipient, 'satoshi');
       assert.equal(withdrawals[4].memo, 'withdrawal tx TXID00000007');
-      assert.equal(withdrawals[4].quantity, 0.297);
+      assert.equal(withdrawals[4].quantity, 0.298);
 
       assert.equal(withdrawals[5].id, 'TXID00000007-fee');
       assert.equal(withdrawals[5].type, 'HIVE');
       assert.equal(withdrawals[5].recipient, CONSTANTS.HIVE_ENGINE_ACCOUNT);
       assert.equal(withdrawals[5].memo, 'fee tx TXID00000007');
-      assert.equal(withdrawals[5].quantity, 0.003);
+      assert.equal(withdrawals[5].quantity, 0.002);
 
       resolve();
     })
@@ -246,7 +246,7 @@ describe('Hive Pegged', function () {
 
       let balance = res;
 
-      assert.equal(balance.balance, 0.87);
+      assert.equal(balance.balance, 0.872);
       assert.equal(balance.account, 'satoshi');
       assert.equal(balance.symbol, CONSTANTS.HIVE_PEGGED_SYMBOL);
 


### PR DESCRIPTION
Part of the fee structure changes going live at 8pm Eastern 1/25/22, described here: https://hive.blog/hive/@aggroed/fee-structure-changes-coming-to-hive-engine