### PR TITLE
NFT Airdrop Contract

### DIFF
--- a/contracts/nftairdrops.js
+++ b/contracts/nftairdrops.js
@@ -69,7 +69,7 @@ const nftTransferVerified = async ({ symbol, to, toType, ids }) => {
   return (verification.length === 0);
 };
 
-// Burns the fee and verifies the transaction
+// Burns the fee and verifies the transaction.
 /* eslint-disable-next-line object-curly-newline */
 const burnFee = async ({ from, fromType, quantity }) => {
   // Don't need to do anything when fee is 0.
@@ -255,8 +255,8 @@ const processAirdrop = async (airdrop, batchSize) => {
         isSignedWithActiveKey: true,
       });
       if (transfer.errors !== undefined) {
-        const succes = (transfer.events) ? transfer.events.map(x => x.data.id) : [];
-        failed.push(...batch.filter(x => !succes.includes(x)));
+        const success = (transfer.events) ? transfer.events.map(x => x.data.id) : [];
+        failed.push(...batch.filter(x => !success.includes(x)));
       }
       if (failed.length > 0 && softFail !== true) {
         // We have errors and the initiator has requested a 'hard fail'.

--- a/contracts/nftairdrops.js
+++ b/contracts/nftairdrops.js
@@ -436,9 +436,9 @@ actions.tick = async () => {
           transactionCount: nftsProcessed,
         });
         if (airdrop.isValid === true) {
-          api.db.update('pendingAirdrops', airdrop);
+          await api.db.update('pendingAirdrops', airdrop);
         } else {
-          api.db.remove('pendingAirdrops', airdrop);
+          await api.db.remove('pendingAirdrops', airdrop);
           // Send remaining locked NFTs, if any, back to the previous owner.
           await reimburseNFTs({ to: airdrop.from, toType: airdrop.fromType, symbol: airdrop.symbol, ids: airdrop.nftIds }); /* eslint-disable-line object-curly-newline */
           if (airdrop.softFail === false && airdrop.nftIds.length > 0) {

--- a/contracts/nftairdrops.js
+++ b/contracts/nftairdrops.js
@@ -294,9 +294,9 @@ actions.createSSC = async () => {
 
     const params = {};
     params.feePerTransaction = '0.1';
-    params.maxTransactionsPerAirdrop = 50000;
+    params.maxTransactionsPerAirdrop = 10000;
     params.maxTransactionsPerAccount = 50;
-    params.maxTransactionsPerBlock = 50;
+    params.maxTransactionsPerBlock = 500;
     params.maxAirdropsPerBlock = 1;
     params.processingBatchSize = 50;
     params.enabledFromTypes = ['user'];

--- a/contracts/nftairdrops.js
+++ b/contracts/nftairdrops.js
@@ -1,0 +1,60 @@
+/* eslint-disable no-await-in-loop */
+/* global actions, api */
+
+const UTILITY_TOKEN_SYMBOL = 'BEE';
+const UTILITY_TOKEN_PRECISION = 8;
+const CONTRACT_NAME = 'nftairdrops';
+
+actions.createSSC = async () => {
+  const tableExists = await api.db.tableExists('pendingNftAirdrops');
+  if (tableExists === false) {
+    await api.db.createTable('pendingNftAirdrops', ['nftAirdropId', 'symbol']);
+    await api.db.createTable('params');
+
+    const params = {};
+    params.feePerTransaction = '0.1';
+    params.maxTransactionsPerBlock = 50;
+    params.maxAirdropsPerBlock = 1;
+    await api.db.insert('params', params);
+  }
+};
+
+actions.updateParams = async (payload) => {
+  if (api.assert(api.sender === api.owner, 'not authorized')) {
+    const {
+      feePerTransaction,
+      maxTransactionsPerBlock,
+      maxAirdropsPerBlock,
+    } = payload;
+
+    const params = await api.db.findOne('params', {});
+
+    if (feePerTransaction) {
+      if (!api.assert(typeof feePerTransaction === 'string' && !api.BigNumber(feePerTransaction).isNaN() && api.BigNumber(feePerTransaction).gte(0), 'invalid feePerTransaction')) return;
+      params.feePerTransaction = feePerTransaction;
+    }
+    if (maxTransactionsPerBlock) {
+      if (!api.assert(Number.isInteger(maxTransactionsPerBlock) && maxTransactionsPerBlock >= 1, 'invalid maxTransactionsPerBlock')) return;
+      params.maxTransactionsPerBlock = maxTransactionsPerBlock;
+    }
+    if (maxAirdropsPerBlock) {
+      if (!api.assert(Number.isInteger(maxAirdropsPerBlock) && maxAirdropsPerBlock >= 1, 'invalid maxAirdropsPerBlock')) return;
+      params.maxAirdropsPerBlock = maxAirdropsPerBlock;
+    }
+
+    await api.db.update('params', params);
+  }
+};
+
+actions.newAirdrop = async (payload) => {
+  const {
+    symbol,
+    list,
+    isSignedWithActiveKey,
+  } = payload;
+
+  if (api.assert(isSignedWithActiveKey === true, 'you must use a custom_json signed with your active key')
+    && api.assert(symbol && typeof symbol === 'string'
+    && list && Array.isArray(list), 'invalid params')) {
+  }
+};

--- a/contracts/nftairdrops.js
+++ b/contracts/nftairdrops.js
@@ -1,18 +1,30 @@
 /* eslint-disable no-await-in-loop */
+/* eslint-disable max-len */
 /* global actions, api */
 
-const UTILITY_TOKEN_SYMBOL = 'BEE';
-const UTILITY_TOKEN_PRECISION = 8;
 const CONTRACT_NAME = 'nftairdrops';
 
+/* eslint-disable no-template-curly-in-string */
+// const UTILITY_TOKEN_SYMBOL = "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'";
+// const UTILITY_TOKEN_PRECISION = "'${CONSTANTS.UTILITY_TOKEN_PRECISION}$'";
+/* eslint-enable no-template-curly-in-string */
+
+
+// BEGIN helper functions
+
+// END helper functions
+
+// BEGIN contract actions
+
 actions.createSSC = async () => {
-  const tableExists = await api.db.tableExists('pendingNftAirdrops');
+  const tableExists = await api.db.tableExists('pendingAirdrops');
   if (tableExists === false) {
-    await api.db.createTable('pendingNftAirdrops', ['nftAirdropId', 'symbol']);
+    await api.db.createTable('pendingAirdrops', ['airdropId', 'symbol']);
     await api.db.createTable('params');
 
     const params = {};
     params.feePerTransaction = '0.1';
+    params.maxTransactionsPerAirdrop = 50000;
     params.maxTransactionsPerBlock = 50;
     params.maxAirdropsPerBlock = 1;
     await api.db.insert('params', params);
@@ -23,6 +35,7 @@ actions.updateParams = async (payload) => {
   if (api.assert(api.sender === api.owner, 'not authorized')) {
     const {
       feePerTransaction,
+      maxTransactionsPerAirdrop,
       maxTransactionsPerBlock,
       maxAirdropsPerBlock,
     } = payload;
@@ -30,31 +43,28 @@ actions.updateParams = async (payload) => {
     const params = await api.db.findOne('params', {});
 
     if (feePerTransaction) {
-      if (!api.assert(typeof feePerTransaction === 'string' && !api.BigNumber(feePerTransaction).isNaN() && api.BigNumber(feePerTransaction).gte(0), 'invalid feePerTransaction')) return;
-      params.feePerTransaction = feePerTransaction;
+      if (api.assert(typeof feePerTransaction === 'string' && !api.BigNumber(feePerTransaction).isNaN() && api.BigNumber(feePerTransaction).gte(0), 'invalid feePerTransaction')) {
+        params.feePerTransaction = feePerTransaction;
+      }
+    }
+    if (maxTransactionsPerAirdrop) {
+      if (api.assert(Number.isInteger(maxTransactionsPerAirdrop) && maxTransactionsPerAirdrop > 0, 'invalid maxTransactionsPerAirdrop')) {
+        params.maxTransactionsPerAirdrop = maxTransactionsPerAirdrop;
+      }
     }
     if (maxTransactionsPerBlock) {
-      if (!api.assert(Number.isInteger(maxTransactionsPerBlock) && maxTransactionsPerBlock >= 1, 'invalid maxTransactionsPerBlock')) return;
-      params.maxTransactionsPerBlock = maxTransactionsPerBlock;
+      if (api.assert(Number.isInteger(maxTransactionsPerBlock) && maxTransactionsPerBlock > 0, 'invalid maxTransactionsPerBlock')) {
+        params.maxTransactionsPerBlock = maxTransactionsPerBlock;
+      }
     }
     if (maxAirdropsPerBlock) {
-      if (!api.assert(Number.isInteger(maxAirdropsPerBlock) && maxAirdropsPerBlock >= 1, 'invalid maxAirdropsPerBlock')) return;
-      params.maxAirdropsPerBlock = maxAirdropsPerBlock;
+      if (api.assert(Number.isInteger(maxAirdropsPerBlock) && maxAirdropsPerBlock > 0, 'invalid maxAirdropsPerBlock')) {
+        params.maxAirdropsPerBlock = maxAirdropsPerBlock;
+      }
     }
 
     await api.db.update('params', params);
   }
 };
 
-actions.newAirdrop = async (payload) => {
-  const {
-    symbol,
-    list,
-    isSignedWithActiveKey,
-  } = payload;
-
-  if (api.assert(isSignedWithActiveKey === true, 'you must use a custom_json signed with your active key')
-    && api.assert(symbol && typeof symbol === 'string'
-    && list && Array.isArray(list), 'invalid params')) {
-  }
-};
+// END contract actions

--- a/contracts/nftairdrops.js
+++ b/contracts/nftairdrops.js
@@ -5,12 +5,245 @@
 const CONTRACT_NAME = 'nftairdrops';
 
 /* eslint-disable no-template-curly-in-string */
-// const UTILITY_TOKEN_SYMBOL = "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'";
-// const UTILITY_TOKEN_PRECISION = "'${CONSTANTS.UTILITY_TOKEN_PRECISION}$'";
+const UTILITY_TOKEN_SYMBOL = "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'";
+const UTILITY_TOKEN_PRECISION = "'${CONSTANTS.UTILITY_TOKEN_PRECISION}$'";
 /* eslint-enable no-template-curly-in-string */
 
+const ALLOWED_TO_TYPES = ['user', 'contract'];
 
 // BEGIN helper functions
+
+// Basic checks if the provided name is a valid account or contract name.
+const isValidAccountName = (name, accountType) => {
+  if (!ALLOWED_TO_TYPES.includes(accountType)) {
+    return false;
+  }
+  if (accountType === 'contract') {
+    return (api.validator.isAlphanumeric(name) && name.length >= 3 && name.length <= 50);
+  }
+  return api.isValidAccountName(name);
+};
+
+// Compare two arrays and return if they have any duplicate elements.
+const arrayHasDuplicates = arr => new Set(arr).size !== arr.length;
+
+// Check if the requested amount of tokens has been transferred to the expected account.
+/* eslint-disable-next-line object-curly-newline */
+const tokenTransferVerified = ({ transaction, from, to, quantity }) => {
+  const { errors, events } = transaction;
+  const eventType = (from === CONTRACT_NAME) ? 'transferFromContract' : 'transferToContract';
+
+  if (errors === undefined
+    && events
+    && events.find(el => el.contract === 'tokens'
+      && el.event === eventType
+      && el.data.symbol === UTILITY_TOKEN_SYMBOL
+      && el.data.from === from
+      && el.data.to === to
+      && el.data.quantity === quantity) !== undefined) {
+    return true;
+  }
+  return false;
+};
+
+// Check if NFTs have been successfully moved to the new account.
+/* eslint-disable-next-line object-curly-newline */
+const nftTransferVerified = async ({ symbol, to, ids }) => {
+  const verification = await api.db.findInTable('nft', symbol + 'instances', /* eslint-disable-line prefer-template */
+    {
+      _id: { $in: ids.map(x => api.BigNumber(x).toNumber()) },
+      account: { $ne: to },
+    },
+    ids.length,
+    0);
+  return (verification.length === 0);
+};
+
+// Transfers the fee to the contract and verifies the transaction.
+const reserveFee = async (quantity) => {
+  const transaction = await api.executeSmartContract('tokens', 'transferToContract', {
+    to: CONTRACT_NAME,
+    symbol: UTILITY_TOKEN_SYMBOL,
+    quantity,
+  });
+  return tokenTransferVerified({ transaction, from: api.sender, to: CONTRACT_NAME, quantity }); /* eslint-disable-line object-curly-newline */
+};
+
+// Burns the fee locked in the contract.
+const burnFee = async (quantity) => {
+  const transaction = await api.executeSmartContract('tokens', 'transferFromContract', {
+    to: 'null',
+    type: 'user',
+    symbol: UTILITY_TOKEN_SYMBOL,
+    quantity,
+  });
+  return tokenTransferVerified({ transaction, from: CONTRACT_NAME, to: 'null', quantity }); /* eslint-disable-line object-curly-newline */
+};
+
+// Sends the fee back to the account specified.
+/* eslint-disable-next-line object-curly-newline */
+const reimburseFee = async ({ to, toType, quantity }) => {
+  const transaction = await api.executeSmartContract('tokens', 'transferFromContract', {
+    to,
+    type: toType,
+    symbol: UTILITY_TOKEN_SYMBOL,
+    quantity,
+  });
+  return tokenTransferVerified({ transaction, from: CONTRACT_NAME, to, quantity }); /* eslint-disable-line object-curly-newline */
+};
+
+// Transfers the NFTs to the contract and verifies the transactions.
+/* eslint-disable-next-line object-curly-newline */
+const reserveNFTs = async ({ symbol, ids, batchSize }) => {
+  for (let i = 0, n = ids.length; i < n; i += batchSize) {
+    const transfer = await api.executeSmartContract('nft', 'transfer', {
+      to: CONTRACT_NAME,
+      toType: 'contract',
+      nfts: [{ symbol, ids: ids.slice(i, i + batchSize) }],
+    });
+    if (transfer.errors !== undefined) break;
+  }
+  return nftTransferVerified({ symbol, to: CONTRACT_NAME, ids });
+};
+
+/* eslint-disable-next-line object-curly-newline */
+const reimburseNFTs = async ({ to, toType, symbol, ids, batchSize = undefined }) => {
+  batchSize = batchSize || ids.length; /* eslint-disable-line no-param-reassign */
+  const reservedNfts = await api.db.findInTable('nft', symbol + 'instances', /* eslint-disable-line prefer-template */
+    {
+      _id: { $in: ids.map(x => api.BigNumber(x).toNumber()) },
+      account: CONTRACT_NAME,
+    },
+    ids.length,
+    0,
+    [{ index: '_id', descending: false }]);
+  for (let i = 0, n = reservedNfts.length; i < n; i += batchSize) {
+    await api.executeSmartContract('nft', 'transfer', {
+      to,
+      toType,
+      nfts: [{ symbol, ids: reservedNfts.slice(i, i + batchSize) }],
+    });
+  }
+  return nftTransferVerified({ symbol, to, ids });
+};
+
+/* eslint-disable-next-line object-curly-newline */
+const parseAndValidateAirdrop = async ({ symbol, sender, senderType, list, startBlockNumber = undefined, softFail = true, params }) => {
+  const instanceTableName = symbol + 'instances'; /* eslint-disable-line prefer-template */
+
+  const airdrop = {
+    isValid: false,
+    softFail: softFail !== false,
+    blockNumber: startBlockNumber || api.blockNumber + 1,
+    airdropId: api.transactionId,
+    symbol,
+    from: sender,
+    fromType: senderType,
+    list,
+    nftIds: [],
+
+    totalFee: null,
+  };
+
+  // Check if symbol exists in db.
+  if (api.assert(
+    typeof symbol === 'string'
+    && api.validator.isAlpha(symbol)
+    && api.validator.isUppercase(symbol)
+    && symbol.length > 0
+    && await api.db.tableExists(instanceTableName) !== false,
+    'invalid symbol',
+  )) {
+    // Validate list of airdrops.
+    if (api.assert(
+      Array.isArray(list)
+      && list.length > 0
+      && api.assert(list.length <= params.maxTransactionsPerAirdrop, 'exceeded airdrop transactions limit') // Don't even bother if the list is already too long.
+      && list.every((element, index) => {
+        if (typeof element === 'object') {
+          const { to, ids } = element;
+          const toType = element.toType || 'user';
+
+          if (api.assert(isValidAccountName(to, toType), `invalid account ${to} at index ${index}`)
+            && api.assert(Array.isArray(ids) && ids.length > 0 && ids.length <= params.maxTransactionsPerAccount && ids.every(i => (typeof i === 'string' && api.BigNumber(i).gt(0))), `invalid nft ids array for account ${to} at index ${index}`)
+            && api.assert(airdrop.nftIds.length < params.maxTransactionsPerAirdrop, 'exceeded airdrop transactions limit')) {
+            airdrop.nftIds.push(...ids);
+            return true;
+          }
+        }
+        return false;
+      }),
+      'invalid list',
+    )) {
+      if (api.assert(!arrayHasDuplicates(airdrop.nftIds), 'airdrop list contains duplicate nfts')) {
+        // Check NFT delegation and ownership. We can do this in a single query.
+        const result = await api.db.findOneInTable('nft', instanceTableName,
+          {
+            _id: { $in: airdrop.nftIds.map(x => api.BigNumber(x).toNumber()) },
+            $or: [{
+              account: { $ne: sender },
+            }, {
+              delegatedTo: { $exists: true },
+            }],
+          });
+        if (api.assert(result === null, 'cannot airdrop nfts that are delegated or not owned by this account')) {
+          // blockNumber shall be greater than the current block number.
+          if (api.assert(Number.isInteger(airdrop.blockNumber) && airdrop.blockNumber > api.blockNumber, 'invalid startBlockNumber')) {
+            airdrop.totalFee = api.BigNumber(params.feePerTransaction).times(airdrop.nftIds.length); //.toFixed(UTILITY_TOKEN_PRECISION);
+            if (api.assert(api.BigNumber(airdrop.totalFee).gte(0), 'unable to calculate total airdrop fee')) {
+              airdrop.isValid = true;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return airdrop;
+};
+
+const processAirdrop = async (airdrop, batchSize) => {
+  const {
+    airdropId,
+    softFail,
+    symbol,
+    list,
+    nftIds,
+  } = airdrop;
+
+  const processed = [];
+  for (let i = list.length - 1; i >= 0; i -= 1) {
+    const { to, toType, ids } = list.pop();
+    // Make sure we don't exceed the batch size for a single item.
+    const batch = ids.splice(0, batchSize - processed.length);
+    // This item still has more transfers pending. Add it back to the list.
+    if (ids.length > 0) list.push({ to, toType, ids });
+
+    if (batch.length > 0) {
+      const transfer = await api.executeSmartContract('nft', 'transfer', {
+        to,
+        toType,
+        nfts: [{ symbol, ids: batch }],
+      });
+      if (!api.assert(transfer.errors === undefined || softFail === true, `error transferring nfts, airdrop ${airdropId} failed`)) {
+        // We have errors and the initiator has requested a 'hard fail'.
+        airdrop.isValid = false; /* eslint-disable-line no-param-reassign */
+        break;
+      }
+    }
+
+    // Add batch to the processed items. If batch size is reached, stop further processing.
+    if (processed.push(...batch) >= batchSize) break;
+  }
+
+  // If we've processed everything from the list, mark the airdrop for cleanup and removal from db.
+  if (list.length === 0) airdrop.isValid = false; /* eslint-disable-line no-param-reassign */
+
+  // Remove processed NFTs from the nftIds array. We use splice here to modify the nftIds array in-place.
+  nftIds.splice(0, nftIds.length, ...nftIds.filter(id => !processed.includes(id)));
+
+  return processed.length;
+};
 
 // END helper functions
 
@@ -25,8 +258,10 @@ actions.createSSC = async () => {
     const params = {};
     params.feePerTransaction = '0.1';
     params.maxTransactionsPerAirdrop = 50000;
+    params.maxTransactionsPerAccount = 50;
     params.maxTransactionsPerBlock = 50;
     params.maxAirdropsPerBlock = 1;
+    params.processingBatchSize = 50;
     await api.db.insert('params', params);
   }
 };
@@ -36,30 +271,42 @@ actions.updateParams = async (payload) => {
     const {
       feePerTransaction,
       maxTransactionsPerAirdrop,
+      maxTransactionsPerAccount,
       maxTransactionsPerBlock,
       maxAirdropsPerBlock,
+      processingBatchSize,
     } = payload;
 
     const params = await api.db.findOne('params', {});
 
-    if (feePerTransaction) {
+    if (feePerTransaction !== undefined) {
       if (api.assert(typeof feePerTransaction === 'string' && !api.BigNumber(feePerTransaction).isNaN() && api.BigNumber(feePerTransaction).gte(0), 'invalid feePerTransaction')) {
         params.feePerTransaction = feePerTransaction;
       }
     }
-    if (maxTransactionsPerAirdrop) {
+    if (maxTransactionsPerAirdrop !== undefined) {
       if (api.assert(Number.isInteger(maxTransactionsPerAirdrop) && maxTransactionsPerAirdrop > 0, 'invalid maxTransactionsPerAirdrop')) {
         params.maxTransactionsPerAirdrop = maxTransactionsPerAirdrop;
       }
     }
-    if (maxTransactionsPerBlock) {
+    if (maxTransactionsPerAccount !== undefined) {
+      if (api.assert(Number.isInteger(maxTransactionsPerAccount) && maxTransactionsPerAccount > 0 && maxTransactionsPerAccount <= params.maxTransactionsPerAirdrop, 'invalid maxTransactionsPerAccount')) {
+        params.maxTransactionsPerAccount = maxTransactionsPerAccount;
+      }
+    }
+    if (maxTransactionsPerBlock !== undefined) {
       if (api.assert(Number.isInteger(maxTransactionsPerBlock) && maxTransactionsPerBlock > 0, 'invalid maxTransactionsPerBlock')) {
         params.maxTransactionsPerBlock = maxTransactionsPerBlock;
       }
     }
-    if (maxAirdropsPerBlock) {
+    if (maxAirdropsPerBlock !== undefined) {
       if (api.assert(Number.isInteger(maxAirdropsPerBlock) && maxAirdropsPerBlock > 0, 'invalid maxAirdropsPerBlock')) {
         params.maxAirdropsPerBlock = maxAirdropsPerBlock;
+      }
+    }
+    if (processingBatchSize !== undefined) {
+      if (api.assert(Number.isInteger(processingBatchSize) && processingBatchSize > 0, 'invalid processingBatchSize')) {
+        params.processingBatchSize = processingBatchSize;
       }
     }
 
@@ -67,4 +314,107 @@ actions.updateParams = async (payload) => {
   }
 };
 
+actions.newAirdrop = async (payload) => {
+  const {
+    symbol,
+    list,
+    startBlockNumber,
+    softFail,
+    isSignedWithActiveKey,
+    callingContractInfo,
+  } = payload;
+
+  if (api.assert(isSignedWithActiveKey === true, 'you must use a custom_json signed with your active key')) {
+    const senderType = (callingContractInfo === undefined) ? 'user' : 'contract';
+    const sender = (senderType === 'user') ? api.sender : callingContractInfo.name;
+    const params = await api.db.findOne('params', {});
+    const airdrop = await parseAndValidateAirdrop({ symbol, sender, senderType, list, startBlockNumber, softFail, params }); /* eslint-disable-line object-curly-newline */
+api.debug(airdrop);
+    if (airdrop.isValid) {
+      // Airdrop data is valid, reserve the fee.
+      const utilityToken = await api.db.findOneInTable('tokens', 'balances', { account: api.sender, symbol: UTILITY_TOKEN_SYMBOL });
+      if (api.assert(utilityToken && api.BigNumber(utilityToken.balance).gte(airdrop.totalFee), 'you must have enough tokens to cover the airdrop fee')) {
+        if (api.assert(await reserveFee(airdrop.totalFee), 'could not secure airdrop fee')) {
+          // Fee has been reserved, transfer NFTs to the contract.
+          if (api.assert(await reserveNFTs({ symbol, ids: airdrop.nftIds, batchSize: params.processingBatchSize }), 'could not secure NFTs')) {
+            // NFTs have been reserved, burn the fee.
+            await burnFee(airdrop.totalFee);
+            // Add airdrop to db to start the process.
+            await api.db.insert('pendingAirdrops', airdrop);
+            api.emit('newNftAirdrop', {
+              airdropId: airdrop.airdropId,
+              sender,
+              symbol,
+              startBlockNumber,
+            });
+          } else {
+            // Somehow could not initiate airdrop. Return the reserved NFTs to the sender.
+            await reimburseNFTs({ to: sender, toType: senderType, symbol, ids: airdrop.nftIds }); /* eslint-disable-line object-curly-newline */
+          }
+        }
+      }
+    }
+  }
+};
+
+actions.tick = async () => {
+  if (api.assert(api.sender === 'null', 'not authorized')) {
+    const params = await api.db.findOne('params', {});
+    const pendingAirdrops = await api.db.find('pendingAirdrops',
+      {
+        blockNumber: { $lte: api.blockNumber },
+      },
+      params.maxAirdropsPerBlock,
+      0,
+      [{ index: '_id', descending: false }]);
+
+    if (pendingAirdrops.length > 0) {
+      const batchSize = Math.floor(params.maxTransactionsPerBlock / pendingAirdrops.length);
+      for (let i = 0, n = pendingAirdrops.length; i < n; i += 1) {
+        const airdrop = pendingAirdrops[i];
+        const nftsProcessed = await processAirdrop(airdrop, batchSize);
+        api.emit('nftAirdropDistribution', {
+          airdropId: airdrop.airdropId,
+          symbol: airdrop.symbol,
+          transactionCount: nftsProcessed,
+        });
+        if (airdrop.isValid === true) {
+          api.db.update('pendingAirdrops', airdrop);
+        } else {
+          api.db.remove('pendingAirdrops', airdrop);
+          // Send remaining locked NFTs, if any, back to the previous owner.
+          await reimburseNFTs({ to: airdrop.from, toType: airdrop.FromType, symbol: airdrop.symbol, ids: airdrop.nftIds }); /* eslint-disable-line object-curly-newline */
+          api.emit('nftAirdropFinished', {
+            airdropId: airdrop.airdropId,
+            symbol: airdrop.symbol,
+          });
+        }
+      }
+    }
+  }
+};
+
 // END contract actions
+
+/*
+    payload = {
+      "symbol": "TUNZ",
+      "list": [
+        {"to": "bait002", "ids": ["11", "12"]},
+        {"to": "aggroed", "ids": ["13", "14"]},
+        {"to": "bennierex", "ids": ["39"]},
+        {"to": "cryptomancer", "ids": ["16", "19", "24"]},
+        {"to": "nftmarket", "toType": "contract", "ids": ["253", "237", "239"]}
+      ]
+    }
+*/
+
+/*
+    payload = {"symbol":"TUNZ","list":[{"to":"bait002","ids":["11"]},]}
+*/
+
+// 1. Parse and validate input
+// 2. Determine if all NFTs exist and belong to sender
+// 3. Transfer instances to contract
+// 4. Transfer instances to contract
+// 5.

--- a/contracts/nftairdrops.js
+++ b/contracts/nftairdrops.js
@@ -459,20 +459,3 @@ actions.tick = async () => {
 };
 
 // END contract actions
-
-/*
-    payload = {
-      "symbol": "TUNZ",
-      "list": [
-        {"to": "bait002", "ids": ["11", "12"]},
-        {"to": "aggroed", "ids": ["13", "14"]},
-        {"to": "bennierex", "ids": ["39"]},
-        {"to": "cryptomancer", "ids": ["16", "19", "24"]},
-        {"to": "nftmarket", "toType": "contract", "ids": ["253", "237", "239"]}
-      ]
-    }
-*/
-
-/*
-    payload = {"symbol":"TUNZ","list":[{"to":"bait002","ids":["11"]},]}
-*/

--- a/contracts/nftairdrops.js
+++ b/contracts/nftairdrops.js
@@ -6,7 +6,7 @@ const CONTRACT_NAME = 'nftairdrops';
 
 /* eslint-disable no-template-curly-in-string */
 const UTILITY_TOKEN_SYMBOL = "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'";
-const UTILITY_TOKEN_PRECISION = "'${CONSTANTS.UTILITY_TOKEN_PRECISION}$'";
+const UTILITY_TOKEN_PRECISION = '${CONSTANTS.UTILITY_TOKEN_PRECISION}$';
 /* eslint-enable no-template-curly-in-string */
 
 const ALLOWED_TO_TYPES = ['user', 'contract'];
@@ -189,7 +189,7 @@ const parseAndValidateAirdrop = async ({ symbol, sender, senderType, list, start
         if (api.assert(result === null, 'cannot airdrop nfts that are delegated or not owned by this account')) {
           // blockNumber shall be greater than the current block number.
           if (api.assert(Number.isInteger(airdrop.blockNumber) && airdrop.blockNumber > api.blockNumber, 'invalid startBlockNumber')) {
-            airdrop.totalFee = api.BigNumber(params.feePerTransaction).times(airdrop.nftIds.length); //.toFixed(UTILITY_TOKEN_PRECISION);
+            airdrop.totalFee = api.BigNumber(params.feePerTransaction).times(airdrop.nftIds.length).toFixed(UTILITY_TOKEN_PRECISION);
             if (api.assert(api.BigNumber(airdrop.totalFee).gte(0), 'unable to calculate total airdrop fee')) {
               airdrop.isValid = true;
             }

--- a/contracts/nftairdrops.js
+++ b/contracts/nftairdrops.js
@@ -151,7 +151,7 @@ const parseAndValidateAirdrop = async ({ symbol, sender, senderType, list, start
     && api.validator.isAlpha(symbol)
     && api.validator.isUppercase(symbol)
     && symbol.length > 0
-    && await api.db.tableExists(instanceTableName) !== false,
+    && await api.db.findOneInTable('nft', 'nfts', { symbol }) !== null,
     'invalid symbol',
   )) {
     // Validate list of airdrops.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test16": "./node_modules/mocha/bin/mocha ./test/nftauction.js",
     "test17": "./node_modules/mocha/bin/mocha ./test/comments.js",
     "test18": "./node_modules/mocha/bin/mocha ./test/ticks.js",
-    "test19": "./node_modules/mocha/bin/mocha ./test/hivepegged.js"
+    "test19": "./node_modules/mocha/bin/mocha ./test/hivepegged.js",
+    "test20": "./node_modules/mocha/bin/mocha ./test/nftairdrops.js"
   },
   "engines": {
     "node": ">=13.7.0",

--- a/test/nftairdrops.js
+++ b/test/nftairdrops.js
@@ -259,23 +259,14 @@ describe('NFT Airdrops Smart Contract', function () {
       // Make sure there were no unexpected errors.
       await tableAsserts.assertNoErrorInLastBlock();
 
-      // Check if the fee has been transferred to the contract and was burned thereafter.
+      // Check if the fee has been burned.
       const blockInfo = await fixture.database.getLatestBlockInfo();
       const eventLog = JSON.parse(blockInfo.transactions[0].logs).events;
       assert.ok(eventLog.find(x => {
         return (
           x.contract === 'tokens'
-          && x.event === 'transferToContract'
+          && x.event === 'transfer'
           && x.data.from === 'bennierex'
-          && x.data.to === 'nftairdrops'
-          && x.data.symbol === `${CONSTANTS.UTILITY_TOKEN_SYMBOL}`
-          && x.data.quantity === '1.50000000');
-      }), 'could not verify fee transfer to contract');
-      assert.ok(eventLog.find(x => {
-        return (
-          x.contract === 'tokens'
-          && x.event === 'transferFromContract'
-          && x.data.from === 'nftairdrops'
           && x.data.to === 'null'
           && x.data.symbol === `${CONSTANTS.UTILITY_TOKEN_SYMBOL}`
           && x.data.quantity === '1.50000000');

--- a/test/nftairdrops.js
+++ b/test/nftairdrops.js
@@ -1,0 +1,73 @@
+/* eslint-disable */
+/* eslint-disable no-await-in-loop */
+/* eslint-disable no-undef */
+/* eslint-disable no-console */
+/* eslint-disable func-names */
+
+const assert = require('assert');
+const { MongoClient } = require('mongodb');
+const { Base64 } = require('js-base64');
+
+const { CONSTANTS } = require('../libs/Constants');
+const { Database } = require('../libs/Database');
+const blockchain = require('../plugins/Blockchain');
+const { Transaction } = require('../libs/Transaction');
+const { setupContractPayload } = require('../libs/util/contractUtil');
+const { Fixture, conf } = require('../libs/util/testing/Fixture');
+const { TableAsserts } = require('../libs/util/testing/TableAsserts');
+const { assertError } = require('../libs/util/testing/Asserts');
+
+const tokensContractPayload = setupContractPayload('tokens', './contracts/tokens.js');
+const contractPayload = setupContractPayload('airdrops', './contracts/nftairdrops.js');
+
+const fixture = new Fixture();
+const tableAsserts = new TableAsserts(fixture);
+
+// smart contract
+describe('NFT Airdrops Smart Contract', function () {
+  this.timeout(20000);
+
+  before((done) => {
+    new Promise(async (resolve) => {
+      client = await MongoClient.connect(conf.databaseURL, { useNewUrlParser: true, useUnifiedTopology: true });
+      db = await client.db(conf.databaseName);
+      await db.dropDatabase();
+      resolve();
+    })
+      .then(() => {
+        done();
+      });
+  });
+
+  after((done) => {
+    new Promise(async (resolve) => {
+      await client.close();
+      resolve();
+    })
+      .then(() => {
+        done();
+      });
+  });
+
+  beforeEach((done) => {
+    // runs before each test in this block
+    new Promise(async (resolve) => {
+      db = await client.db(conf.databaseName);
+      resolve();
+    })
+      .then(() => {
+        done();
+      });
+  });
+
+  afterEach((done) => {
+    // runs after each test in this block
+    new Promise(async (resolve) => {
+      await db.dropDatabase();
+      resolve();
+    })
+      .then(() => {
+        done();
+      });
+  });
+});

--- a/test/nftairdrops.js
+++ b/test/nftairdrops.js
@@ -16,9 +16,11 @@ const { setupContractPayload } = require('../libs/util/contractUtil');
 const { Fixture, conf } = require('../libs/util/testing/Fixture');
 const { TableAsserts } = require('../libs/util/testing/TableAsserts');
 const { assertError } = require('../libs/util/testing/Asserts');
+const { Resolver } = require('dns');
 
 const tokensContractPayload = setupContractPayload('tokens', './contracts/tokens.js');
-const contractPayload = setupContractPayload('airdrops', './contracts/nftairdrops.js');
+const nftContractPayload = setupContractPayload('nft', './contracts/nft.js');
+const contractPayload = setupContractPayload('nftairdrops', './contracts/nftairdrops.js');
 
 const fixture = new Fixture();
 const tableAsserts = new TableAsserts(fixture);
@@ -67,6 +69,94 @@ describe('NFT Airdrops Smart Contract', function () {
       resolve();
     })
       .then(() => {
+        done();
+      });
+  });
+
+  it('should update parameters', (done) => {
+    new Promise(async (resolve) => {
+
+      await fixture.setUp();
+
+      const refBlockNumber = fixture.getNextRefBlockNumber();
+      const transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(contractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"feePerTransaction": "0.3", "maxTransactionsPerAirdrop": 30001, "maxTransactionsPerBlock": 31, "maxAirdropsPerBlock": 3}'));
+
+      const block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+
+      // make sure there were no unexpected errors
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      // parameters should have changed to the new values
+      const params = await fixture.database.findOne({
+        contract: 'nftairdrops',
+        table: 'params',
+        query: {},
+      });
+
+      assert.equal(params.feePerTransaction, '0.3');
+      assert.equal(params.maxTransactionsPerAirdrop, 30001);
+      assert.equal(params.maxTransactionsPerBlock, 31);
+      assert.equal(params.maxAirdropsPerBlock, 3);
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
+
+  it('should not update parameters', (done) => {
+    new Promise(async (resolve) => {
+
+      await fixture.setUp();
+
+      const refBlockNumber = fixture.getNextRefBlockNumber();
+      const transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(contractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"feePerTransaction": 0.3}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"maxTransactionsPerAirdrop": "30001"}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"maxTransactionsPerBlock": null}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"maxAirdropsPerBlock": []}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"wrongKey": "whatever"}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'updateParams', '{"feePerTransaction": "0.3", "maxTransactionsPerAirdrop": 30001, "maxTransactionsPerBlock": 31, "maxAirdropsPerBlock": 3}'));
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD1',
+        prevRefHiveBlockId: 'ABCD2',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+
+      // check parameters remain unchanged
+      const params = await fixture.database.findOne({
+        contract: 'nftairdrops',
+        table: 'params',
+        query: {},
+      });
+
+      assert.equal(params.feePerTransaction, '0.1');
+      assert.equal(params.maxTransactionsPerAirdrop, 50000);
+      assert.equal(params.maxTransactionsPerBlock, 50);
+      assert.equal(params.maxAirdropsPerBlock, 1);
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
         done();
       });
   });

--- a/test/nftairdrops.js
+++ b/test/nftairdrops.js
@@ -5,22 +5,37 @@
 /* eslint-disable func-names */
 
 const assert = require('assert');
-const { MongoClient } = require('mongodb');
-const { Base64 } = require('js-base64');
+const BigNumber = require('bignumber.js');
 
+const { MongoClient } = require('mongodb');
 const { CONSTANTS } = require('../libs/Constants');
-const { Database } = require('../libs/Database');
-const blockchain = require('../plugins/Blockchain');
 const { Transaction } = require('../libs/Transaction');
 const { setupContractPayload } = require('../libs/util/contractUtil');
 const { Fixture, conf } = require('../libs/util/testing/Fixture');
 const { TableAsserts } = require('../libs/util/testing/TableAsserts');
 const { assertError } = require('../libs/util/testing/Asserts');
-const { Resolver } = require('dns');
 
 const tokensContractPayload = setupContractPayload('tokens', './contracts/tokens.js');
 const nftContractPayload = setupContractPayload('nft', './contracts/nft.js');
 const contractPayload = setupContractPayload('nftairdrops', './contracts/nftairdrops.js');
+
+// prepare test contract for creating airdrops via another contract
+const testSmartContractCode = `
+  actions.createSSC = function (payload) {
+    // Initialize the smart contract via the create action
+  }
+
+  actions.doAirdrop = async function (payload) {
+    await api.executeSmartContract('nftairdrops', 'newAirdrop', payload);
+  }
+`;
+base64ContractCode = Base64.encode(testSmartContractCode);
+
+const testContractPayload = {
+  name: 'testcontract',
+  params: '',
+  code: base64ContractCode,
+};
 
 const fixture = new Fixture();
 const tableAsserts = new TableAsserts(fixture);
@@ -81,7 +96,7 @@ describe('NFT Airdrops Smart Contract', function () {
       const refBlockNumber = fixture.getNextRefBlockNumber();
       const transactions = [];
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(contractPayload)));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"feePerTransaction": "0.3", "maxTransactionsPerAirdrop": 30001, "maxTransactionsPerBlock": 31, "maxAirdropsPerBlock": 3}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"feePerTransaction": "0.3", "maxTransactionsPerAirdrop": 30001, "maxTransactionsPerAccount": 11, "maxTransactionsPerBlock": 31, "maxAirdropsPerBlock": 3, "processingBatchSize": 33}'));
 
       const block = {
         refHiveBlockNumber: refBlockNumber,
@@ -103,10 +118,12 @@ describe('NFT Airdrops Smart Contract', function () {
         query: {},
       });
 
-      assert.equal(params.feePerTransaction, '0.3');
-      assert.equal(params.maxTransactionsPerAirdrop, 30001);
-      assert.equal(params.maxTransactionsPerBlock, 31);
-      assert.equal(params.maxAirdropsPerBlock, 3);
+      assert.strictEqual(params.feePerTransaction, '0.3');
+      assert.strictEqual(params.maxTransactionsPerAirdrop, 30001);
+      assert.strictEqual(params.maxTransactionsPerAccount, 11);
+      assert.strictEqual(params.maxTransactionsPerBlock, 31);
+      assert.strictEqual(params.maxAirdropsPerBlock, 3);
+      assert.strictEqual(params.processingBatchSize, 33);
 
       resolve();
     })
@@ -126,20 +143,35 @@ describe('NFT Airdrops Smart Contract', function () {
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(contractPayload)));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"feePerTransaction": 0.3}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"maxTransactionsPerAirdrop": "30001"}'));
-      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"maxTransactionsPerBlock": null}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"maxTransactionsPerAccount": -3}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"maxTransactionsPerAccount": 50001}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"maxTransactionsPerBlock": -3}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"maxAirdropsPerBlock": []}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"processingBatchSize": 0}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"wrongKey": "whatever"}'));
       transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'updateParams', '{"feePerTransaction": "0.3", "maxTransactionsPerAirdrop": 30001, "maxTransactionsPerBlock": 31, "maxAirdropsPerBlock": 3}'));
 
       let block = {
         refHiveBlockNumber: refBlockNumber,
-        refHiveBlockId: 'ABCD1',
-        prevRefHiveBlockId: 'ABCD2',
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
         timestamp: '2018-06-01T00:00:00',
         transactions,
       };
 
       await fixture.sendBlock(block);
+
+      const res = await fixture.database.getLatestBlockInfo();
+      const txs = res.transactions;
+
+      assertError(txs[1], 'invalid feePerTransaction');
+      assertError(txs[2], 'invalid maxTransactionsPerAirdrop');
+      assertError(txs[3], 'invalid maxTransactionsPerAccount'); // maxTransactionsPerAccount > 0
+      assertError(txs[4], 'invalid maxTransactionsPerAccount'); // maxTransactionsPerAccount <= params.maxTransactionsPerAirdrop
+      assertError(txs[5], 'invalid maxTransactionsPerBlock');
+      assertError(txs[6], 'invalid maxAirdropsPerBlock');
+      assertError(txs[7], 'invalid processingBatchSize');
+      assertError(txs[9], 'not authorized');
 
       // check parameters remain unchanged
       const params = await fixture.database.findOne({
@@ -148,10 +180,675 @@ describe('NFT Airdrops Smart Contract', function () {
         query: {},
       });
 
-      assert.equal(params.feePerTransaction, '0.1');
-      assert.equal(params.maxTransactionsPerAirdrop, 50000);
-      assert.equal(params.maxTransactionsPerBlock, 50);
-      assert.equal(params.maxAirdropsPerBlock, 1);
+      assert.strictEqual(params.feePerTransaction, '0.1');
+      assert.strictEqual(params.maxTransactionsPerAirdrop, 50000);
+      assert.strictEqual(params.maxTransactionsPerAccount, 50);
+      assert.strictEqual(params.maxTransactionsPerBlock, 50);
+      assert.strictEqual(params.maxAirdropsPerBlock, 1);
+      assert.strictEqual(('wrongKey' in params), false);
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
+
+  it('should initiate airdrop and run distribution', (done) => {
+    new Promise(async (resolve) => {
+
+      await fixture.setUp();
+
+      let refBlockNumber = fixture.getNextRefBlockNumber();
+      let transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(nftContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(contractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"feePerTransaction": "0.15", "maxTransactionsPerAirdrop": 10, "maxTransactionsPerAccount": 3, "maxTransactionsPerBlock": 4, "maxAirdropsPerBlock": 2, "processingBatchSize": 5}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'registerTick', '{ "contractName": "nftairdrops", "tickAction": "tick" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to": "bennierex", "quantity": "1984", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'create', '{ "isSignedWithActiveKey": true, "name": "test NFT", "symbol": "TSTNFT", "url": "http://mynft.com", "maxSupply": "1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'addProperty', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFT", "name":"color", "type":"string" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'issueMultiple', `{ "isSignedWithActiveKey": true, "instances": [
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "blue"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "orange"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "yellow"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "red"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "purple"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "green"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "white"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "grey"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "black"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "transparent"} }
+      ] }`));
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+
+      // Make sure there were no unexpected errors.
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      const transactionId = fixture.getNextTxId();
+      transactions = [];
+      transactions.push(new Transaction(refBlockNumber, transactionId, 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1", "2"] },
+        { "to": "aggroed", "ids": ["3", "4"] },
+        { "to": "cryptomancer", "ids": ["5", "6", "7"] },
+        { "to": "nftmarket", "toType": "contract", "ids": ["8", "9", "10"] }
+      ] }`));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      }
+
+      await fixture.sendBlock(block);
+
+      // Make sure there were no unexpected errors.
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      // Check if the fee has been transferred to the contract and was burned thereafter.
+      const blockInfo = await fixture.database.getLatestBlockInfo();
+      const eventLog = JSON.parse(blockInfo.transactions[0].logs).events;
+      assert.ok(eventLog.find(x => {
+        return (
+          x.contract === 'tokens'
+          && x.event === 'transferToContract'
+          && x.data.from === 'bennierex'
+          && x.data.to === 'nftairdrops'
+          && x.data.symbol === `${CONSTANTS.UTILITY_TOKEN_SYMBOL}`
+          && x.data.quantity === '1.50000000');
+      }), 'could not verify fee transfer to contract');
+      assert.ok(eventLog.find(x => {
+        return (
+          x.contract === 'tokens'
+          && x.event === 'transferFromContract'
+          && x.data.from === 'nftairdrops'
+          && x.data.to === 'null'
+          && x.data.symbol === `${CONSTANTS.UTILITY_TOKEN_SYMBOL}`
+          && x.data.quantity === '1.50000000');
+      }), 'could not verify fee was burned');
+
+      // Make sure all expected NFTs have been transferred to the contract.
+      let nftInstances = await fixture.database.find({
+        contract: 'nft',
+        table: 'TSTNFTinstances',
+        query: {
+          _id: { $in: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+          account: 'nftairdrops',
+          ownedBy: 'c',
+        }
+      });
+      assert.strictEqual(nftInstances.length, 10);
+
+      // Check if airdrop has been correctly added to the database.
+      let pendingAirdrop = await fixture.database.findOne({
+        contract: 'nftairdrops',
+        table: 'pendingAirdrops',
+        query: {},
+      });
+      assert.strictEqual(pendingAirdrop.isValid, true);
+      assert.strictEqual(pendingAirdrop.softFail, true);
+      assert.strictEqual(pendingAirdrop.blockNumber, 3);
+      assert.strictEqual(pendingAirdrop.airdropId, transactionId);
+      assert.strictEqual(pendingAirdrop.symbol, 'TSTNFT');
+      assert.strictEqual(pendingAirdrop.from, 'bennierex');
+      assert.strictEqual(pendingAirdrop.fromType, 'user');
+      assert.strictEqual(pendingAirdrop.list.length, 4);
+      assert.strictEqual(pendingAirdrop.nftIds.length, 10);
+      assert.strictEqual(pendingAirdrop.nftIds.every((val, idx) => val === ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'][idx]), true);
+      assert.strictEqual(pendingAirdrop.totalFee, '1.50000000');
+
+      // Assert airdrop execution for the next three blocks.
+      for (let i = 0; i < 3; i += 1) {
+        refBlockNumber = fixture.getNextRefBlockNumber();
+        transactions = [];
+        transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'whatever', 'whatever', '')); // No-op to force block creation.
+        block = {
+          refHiveBlockNumber: refBlockNumber,
+          refHiveBlockId: 'ABCD2',
+          prevRefHiveBlockId: 'ABCD1',
+          timestamp: '2018-06-01T00:00:00',
+          transactions,
+        }
+        await fixture.sendBlock(block);
+
+        const blockInfo = await fixture.database.getLatestBlockInfo();
+        const virtualEventLog = JSON.parse(blockInfo.virtualTransactions[0].logs).events;
+        const nftAirdropDistributionEvent = virtualEventLog.find(x => x.event === 'nftAirdropDistribution');
+        const nftAirdropFinishedEvent = virtualEventLog.find(x => x.event === 'nftAirdropFinished');
+        const nftAirdropFailedEvent = virtualEventLog.find(x => x.event === 'nftAirdropFailed');
+        const nftTransferEvents = virtualEventLog.filter(x => x.event === 'transfer');
+        assert.ok(nftAirdropDistributionEvent, 'expected airdropDistribution event');
+        if (i < 2) {
+          assert.strictEqual(nftAirdropDistributionEvent.data.transactionCount, 4);
+          assert.strictEqual(nftTransferEvents.length, 4);
+          assert.strictEqual(nftAirdropFailedEvent, undefined, 'did not expect nftAirdropFailed event');
+          assert.strictEqual(nftAirdropFinishedEvent, undefined, 'did not expect nftAirdropFinished event');
+        } else {
+          assert.strictEqual(nftAirdropDistributionEvent.data.transactionCount, 2);
+          assert.strictEqual(nftTransferEvents.length, 2);
+          assert.ok(nftAirdropFinishedEvent, 'expected nftAirdropFinished event');
+        }
+      }
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
+
+  it('should initiate multiple airdrops and run distribution simultaneous', (done) => {
+    new Promise(async (resolve) => {
+
+      await fixture.setUp();
+
+      let refBlockNumber = fixture.getNextRefBlockNumber();
+      let transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(nftContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(contractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(testContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"feePerTransaction": "0.1", "maxTransactionsPerAirdrop": 10, "maxTransactionsPerAccount": 3, "maxTransactionsPerBlock": 4, "maxAirdropsPerBlock": 2, "processingBatchSize": 5}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'registerTick', '{ "contractName": "nftairdrops", "tickAction": "tick" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to": "bennierex", "quantity": "1984", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'create', '{ "isSignedWithActiveKey": true, "name": "test NFT", "symbol": "TSTNFT", "url": "http://mynft.com", "maxSupply": "1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'addProperty', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFT", "name":"color", "type":"string" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'issueMultiple', `{ "isSignedWithActiveKey": true, "instances": [
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "blue"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "orange"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "yellow"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "red"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "purple"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "green"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "white"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "grey"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "black"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "transparent"} }
+      ] }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to": "bait002", "quantity": "100", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'create', '{ "isSignedWithActiveKey": true, "name": "contract owned test NFT 2", "symbol": "TSTNFTC", "url": "http://mynft.com", "maxSupply": "1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'addProperty', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFTC", "name":"series", "type":"string" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'issueMultiple', `{ "isSignedWithActiveKey": true, "instances": [
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "abcdef"} },
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "abcdef"} },
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "abcdef"} },
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "abcdef"} },
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "abcdef"} },
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "ghijkl"} },
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "ghijkl"} },
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "ghijkl"} },
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "ghijkl"} },
+        { "symbol": "TSTNFTC", "to":"bait002", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"series": "ghijkl"} }
+      ] }`));
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+
+      // Make sure there were no unexpected errors.
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      const airdrops = {
+        TSTNFT: [
+          { to: "bait002", ids: ["1", "2"] },
+          { to: "aggroed", ids: ["3", "4"] },
+          { to: "cryptomancer", ids: ["5", "6", "7"] },
+          { to: "nftmarket", toType: "contract", ids: ["8", "9", "10"] },
+        ],
+        TSTNFTC: [
+          { to: "bennierex", ids: ["10", "9"] },
+          { to: "aggroed", ids: ["8", "7"] },
+          { to: "cryptomancer", ids: ["6", "5", "4"] },
+          { to: "nftmarket", toType: "contract", ids: ["3", "2", "1"] },
+        ],
+      }
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions = [];
+      // Airdrop directly initiated by user.
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": ${JSON.stringify(airdrops['TSTNFT'])} }`));
+      // Airdrop initiated by user via other contract.
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bait002', 'testcontract', 'doAirdrop', `{ "isSignedWithActiveKey": true, "fromType": "user", "startBlockNumber": 4, "symbol": "TSTNFTC", "list": ${JSON.stringify(airdrops['TSTNFTC'])} }`));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      }
+
+      await fixture.sendBlock(block);
+
+      // Make sure there were no unexpected errors.
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      // Make sure all expected NFTs have been transferred to the contract.
+      let nftInstances = await fixture.database.find({
+        contract: 'nft',
+        table: 'TSTNFTinstances',
+        query: {
+          _id: { $in: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+          account: 'nftairdrops',
+          ownedBy: 'c',
+        }
+      });
+      assert.strictEqual(nftInstances.length, 10);
+      nftInstances = await fixture.database.find({
+        contract: 'nft',
+        table: 'TSTNFTCinstances',
+        query: {
+          _id: { $in: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+          account: 'nftairdrops',
+          ownedBy: 'c',
+        }
+      });
+      assert.strictEqual(nftInstances.length, 10);
+
+      // Check if airdrop has been correctly added to the database.
+      let pendingAirdrops = await fixture.database.find({
+        contract: 'nftairdrops',
+        table: 'pendingAirdrops',
+        query: {},
+      });
+      assert.strictEqual(pendingAirdrops.length, 2);
+      assert.strictEqual(pendingAirdrops[0].symbol, 'TSTNFT');
+      assert.strictEqual(pendingAirdrops[0].from, 'bennierex');
+      assert.strictEqual(pendingAirdrops[0].fromType, 'user');
+      assert.strictEqual(pendingAirdrops[0].nftIds.length, 10);
+      assert.strictEqual(pendingAirdrops[1].symbol, 'TSTNFTC');
+      assert.strictEqual(pendingAirdrops[1].from, 'bait002');
+      assert.strictEqual(pendingAirdrops[1].fromType, 'user');
+      assert.strictEqual(pendingAirdrops[1].nftIds.length, 10);
+
+      const pendingAirdropsIds = pendingAirdrops.map((x) => { return x.airdropId });
+
+      // Assert airdrop execution for the next three blocks.
+      for (let i = 0; i < 6; i += 1) {
+        refBlockNumber = fixture.getNextRefBlockNumber();
+        transactions = [];
+        transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'whatever', 'whatever', '')); // No-op to force block creation.
+
+        block = {
+          refHiveBlockNumber: refBlockNumber,
+          refHiveBlockId: 'ABCD2',
+          prevRefHiveBlockId: 'ABCD1',
+          timestamp: '2018-06-01T00:00:00',
+          transactions,
+        }
+
+        await fixture.sendBlock(block);
+
+        const blockInfo = await fixture.database.getLatestBlockInfo();
+        const virtualEventLog = blockInfo.virtualTransactions.map(x => JSON.parse(x.logs).events).flat();
+        const nftAirdropDistributionEvents = virtualEventLog.filter(x => x.event === 'nftAirdropDistribution');
+        const nftAirdropFinishedEvents = virtualEventLog.filter(x => x.event === 'nftAirdropFinished');
+        const nftTransferEvents = virtualEventLog.filter(x => x.contract ==='nft' && x.event === 'transfer');
+
+        if (i === 0) {
+          // The first airdrop should have started, distributing 4 NFT's.
+          assert.strictEqual(nftTransferEvents.length, 4);
+          assert.strictEqual(nftAirdropDistributionEvents.length, 1);
+          assert.strictEqual(nftAirdropDistributionEvents[0].data.airdropId, pendingAirdropsIds[0]);
+          assert.strictEqual(nftAirdropDistributionEvents[0].data.symbol, 'TSTNFT');
+          assert.strictEqual(nftAirdropDistributionEvents[0].data.transactionCount, 4);
+        }
+        if (i >= 1 && i <= 3) {
+          // Now both airdrops should be distributing 2 NFT's each.
+          assert.strictEqual(nftTransferEvents.length, 4);
+          assert.strictEqual(nftAirdropDistributionEvents.length, 2);
+          assert.strictEqual(nftAirdropDistributionEvents[0].data.airdropId, pendingAirdropsIds[0]);
+          assert.strictEqual(nftAirdropDistributionEvents[0].data.symbol, 'TSTNFT');
+          assert.strictEqual(nftAirdropDistributionEvents[0].data.transactionCount, 2);
+          assert.strictEqual(nftAirdropDistributionEvents[1].data.airdropId, pendingAirdropsIds[1]);
+          assert.strictEqual(nftAirdropDistributionEvents[1].data.symbol, 'TSTNFTC');
+          assert.strictEqual(nftAirdropDistributionEvents[1].data.transactionCount, 2);
+        }
+        if (i === 3) {
+          // First airdrop should have finished in this block.
+          assert.strictEqual(nftAirdropFinishedEvents.length, 1);
+          assert.strictEqual(nftAirdropFinishedEvents[0].data.airdropId, pendingAirdropsIds[0]);
+        }
+        if (i === 4) {
+          // Second airdrop should have finished as well.
+          assert.strictEqual(nftAirdropDistributionEvents[0].data.airdropId, pendingAirdropsIds[1]);
+          assert.strictEqual(nftAirdropDistributionEvents[0].data.symbol, 'TSTNFTC');
+          assert.strictEqual(nftAirdropDistributionEvents[0].data.transactionCount, 4);
+          assert.strictEqual(nftTransferEvents.length, 4);
+          assert.strictEqual(nftAirdropFinishedEvents.length, 1);
+          assert.strictEqual(nftAirdropFinishedEvents[0].data.airdropId, pendingAirdropsIds[1]);
+        }
+        if (i === 5) {
+          // Expecting no airdrop activity in this block.
+          assert.strictEqual(nftAirdropDistributionEvents.length, 0);
+          assert.strictEqual(nftAirdropFinishedEvents.length, 0);
+          assert.strictEqual(nftTransferEvents.length, 0);
+        }
+      }
+
+      // Check if all NFT's are transferred to the expected accounts.
+      const tstnftInstances = await fixture.database.find({
+        contract: 'nft',
+        table: 'TSTNFTinstances',
+        query: {
+          _id: { $in: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+          account: { $in: ['bait002', 'aggroed', 'cryptomancer', 'nftmarket'] },
+        },
+        indexes: [{ index: '_id', descending: false }],
+      });
+      assert.strictEqual(tstnftInstances.length, 10);
+      for (let i = 0; i < airdrops.TSTNFT.length; i += 1) {
+        const { to, toType, ids } = airdrops.TSTNFT[i];
+        const ownedBy = (toType === 'contract') ? 'c' : 'u';
+        const nfts = tstnftInstances.filter(x => x.account === to && x.ownedBy === ownedBy && ids.includes(BigNumber(x._id).toString()));
+        assert.strictEqual(ids.length, nfts.length);
+      }
+      const tstnftcInstances = await fixture.database.find({
+        contract: 'nft',
+        table: 'TSTNFTCinstances',
+        query: {
+          _id: { $in: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+          account: { $in: ['bennierex', 'aggroed', 'cryptomancer', 'nftmarket'] },
+        },
+        indexes: [{ index: '_id', descending: true }],
+      });
+      assert.strictEqual(tstnftcInstances.length, 10);
+      for (let i = 0; i < airdrops.TSTNFTC.length; i += 1) {
+        const { to, toType, ids } = airdrops.TSTNFTC[i];
+        const ownedBy = (toType === 'contract') ? 'c' : 'u';
+        const nfts = tstnftcInstances.filter(x => x.account === to && x.ownedBy === ownedBy && ids.includes(BigNumber(x._id).toString()));
+        assert.strictEqual(ids.length, nfts.length);
+      }
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
+
+  it('should initiate airdrop and fail during distribution', (done) => {
+    new Promise(async (resolve) => {
+
+      await fixture.setUp();
+
+      let refBlockNumber = fixture.getNextRefBlockNumber();
+      let transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(nftContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(contractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(testContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"feePerTransaction": "0.1", "maxTransactionsPerAirdrop": 50, "maxTransactionsPerAccount": 15, "maxTransactionsPerBlock": 50, "maxAirdropsPerBlock": 2, "processingBatchSize": 50}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'registerTick', '{ "contractName": "nftairdrops", "tickAction": "tick" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to": "bennierex", "quantity": "1984", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'create', '{ "isSignedWithActiveKey": true, "name": "test NFT", "symbol": "TSTNFT", "url": "http://mynft.com", "maxSupply": "1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'addProperty', '{ "isSignedWithActiveKey":true, "symbol":"TSTNFT", "name":"color", "type":"string" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'issueMultiple', `{ "isSignedWithActiveKey": true, "instances": [
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "blue"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "orange"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "yellow"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "red"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "purple"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "green"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "white"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "grey"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "black"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "silver"} }
+      ] }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'issueMultiple', `{ "isSignedWithActiveKey": true, "instances": [
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "lime"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "olive"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "navy"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "aqua"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "transparent"} }
+      ] }`));
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+
+      // Make sure there were no unexpected errors.
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions = [];
+      // Hard fail
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "softFail": false, "list": [
+        { "to": "bait002", "ids": ["1", "2"] },
+        { "to": "aggroed", "ids": ["3", "4", "9"] },
+        { "to": "nftairdrops", "toType": "contract", "ids": ["8", "10"] },
+        { "to": "cryptomancer", "ids": ["5", "6", "7"] }
+      ] }`));
+      // Soft fail
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["14"] },
+        { "to": "aggroed", "ids": ["15"] },
+        { "to": "nftairdrops", "toType": "contract", "ids": ["12", "13"] },
+        { "to": "cryptomancer", "ids": ["11"] }
+      ] }`));
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      }
+
+      await fixture.sendBlock(block);
+
+      // Make sure there were no unexpected errors.
+      await tableAsserts.assertNoErrorInLastBlock();
+
+      // Make sure all expected NFTs have been transferred to the contract.
+      let nftInstances = await fixture.database.find({
+        contract: 'nft',
+        table: 'TSTNFTinstances',
+        query: {
+          _id: { $in: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] },
+          account: 'nftairdrops',
+          ownedBy: 'c',
+        }
+      });
+      assert.strictEqual(nftInstances.length, 15);
+
+      for (let i = 0; i < 5; i += 1) {
+        refBlockNumber = fixture.getNextRefBlockNumber();
+        transactions = [];
+        transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'whatever', 'whatever', '')); // No-op to force block creation.
+        block = {
+          refHiveBlockNumber: refBlockNumber,
+          refHiveBlockId: 'ABCD2',
+          prevRefHiveBlockId: 'ABCD1',
+          timestamp: '2018-06-01T00:00:00',
+          transactions,
+        }
+        await fixture.sendBlock(block);
+      }
+
+      // Check if all NFT's are transferred to the expected accounts.
+      const expectedResult = [
+        { to: "bait002", ids: ["14"] },
+        { to: "aggroed", ids: ["15"] },
+        { to: "cryptomancer", ids: ["5", "6", "7", "11"] },
+        { to: "bennierex", ids: ["1", "2", "3", "4", "8", "9", "10", "12", "13"] }, // These should have been returned to sender.
+      ];
+      const tstnftInstances = await fixture.database.find({
+        contract: 'nft',
+        table: 'TSTNFTinstances',
+        query: {
+          _id: { $in: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] },
+        },
+        indexes: [{ index: '_id', descending: false }],
+      });
+      assert.strictEqual(tstnftInstances.length, 15);
+      for (let i = 0; i < expectedResult.length; i += 1) {
+        const { to, ids } = expectedResult[i];
+        const nfts = tstnftInstances.filter(x => x.account === to && x.ownedBy === 'u' && ids.includes(BigNumber(x._id).toString()));
+        assert.strictEqual(ids.length, nfts.length);
+      }
+
+      resolve();
+    })
+      .then(() => {
+        fixture.tearDown();
+        done();
+      });
+  });
+
+  it('should not initiate airdrop', (done) => {
+    new Promise(async (resolve) => {
+
+      await fixture.setUp();
+
+      let refBlockNumber = fixture.getNextRefBlockNumber();
+      let transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(nftContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(contractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(testContractPayload)));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'nftairdrops', 'updateParams', '{"feePerTransaction": "0.15", "maxTransactionsPerAirdrop": 3, "maxTransactionsPerAccount": 2, "maxTransactionsPerBlock": 4, "maxAirdropsPerBlock": 2, "processingBatchSize": 5}'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'registerTick', '{ "contractName": "nftairdrops", "tickAction": "tick" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to": "nftairdrops", "quantity": "10", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transfer', `{ "symbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to": "bennierex", "quantity": "1100.35", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'create', '{ "isSignedWithActiveKey": true, "name": "test NFT", "symbol": "TSTNFT", "url": "http://mynft.com", "maxSupply": "1000" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'addProperty', '{ "isSignedWithActiveKey": true, "symbol":"TSTNFT", "name":"color", "type":"string" }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'enableDelegation', '{ "isSignedWithActiveKey": true, "symbol":"TSTNFT", "undelegationCooldown": 5 }'));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'issueMultiple', `{ "isSignedWithActiveKey": true, "instances": [
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "blue"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "orange"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "yellow"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "red"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "purple"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "green"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "white"} },
+        { "symbol": "TSTNFT", "to":"testcontract", "toType": "contract", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "grey"} },
+        { "symbol": "TSTNFT", "to":"yabapmatt", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "black"} },
+        { "symbol": "TSTNFT", "to":"bennierex", "feeSymbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "properties": {"color": "transparent"} }
+      ] }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nft', 'delegate', '{ "isSignedWithActiveKey": true, "to": "cryptomancer", "nfts": [ {"symbol":"TSTNFT", "ids":["10"]} ] }'));
+
+      let block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      };
+
+      await fixture.sendBlock(block);
+
+      refBlockNumber = fixture.getNextRefBlockNumber();
+      transactions = [];
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": false, "symbol": "TSTNFT", "list": [] }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "DOESNTEXIST", "list": [] }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TsTnFt", "list": [] }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "aggroed", "ids": ["2"] }, { "to": "cryptomancer", "ids": ["3"] }, { "to": "bennierex", "ids": ["4"] }
+      ] }`)); // 3
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1", "3", "5"] }, { "to": "aggroed", "ids": ["2", "4"] }, { "to": "cryptomancer", "ids": ["6", "7"] }, { "to": "bennierex", "ids": ["44"] }
+      ] }`)); // 4
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "aggroed", "ids": ["2"] }, { "to": "be", "ids": ["3"] }
+      ] }`)); // 5
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "bennierex", "ids": "44" }
+      ] }`)); // 6
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "bennierex", "ids": [] }
+      ] }`)); // 7
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bennierex", "ids": ["1", "2", "3"] }
+      ] }`)); // 8
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bennierex", "ids": [1, 2, 3] }
+      ] }`)); // 9
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bennierex", "ids": ["a", "1.0", "zzzz"] }
+      ] }`)); // 10
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "aggroed", "ids": ["2"] }, { "to": "bennierex", "ids": ["1"] }
+      ] }`)); // 11
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "aggroed", "ids": ["2"] }, { "to": "bennierex", "ids": ["9"] }
+      ] }`)); // 12
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "aggroed", "ids": ["2"] }, { "to": "bennierex", "ids": ["10"] }
+      ] }`)); // 13
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "aggroed", "ids": ["2"] }, { "to": "bennierex", "ids": ["3"] }
+      ], "startBlockNumber": "100000009" }`)); // 14
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "aggroed", "ids": ["2"] }, { "to": "bennierex", "ids": ["3"] }
+      ], "startBlockNumber": 2 }`)); // 15
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'nftairdrops', 'newAirdrop', `{ "isSignedWithActiveKey": true, "symbol": "TSTNFT", "list": [
+        { "to": "bait002", "ids": ["1"] }, { "to": "aggroed", "ids": ["2"] }, { "to": "bennierex", "ids": ["3"] }
+      ] }`)); // 16
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'tokens', 'transferToContract', `{ "symbol": "${CONSTANTS.UTILITY_TOKEN_SYMBOL}", "to": "testcontract", "quantity": "100", "isSignedWithActiveKey": true }`));
+      transactions.push(new Transaction(refBlockNumber, fixture.getNextTxId(), 'bennierex', 'testcontract', 'doAirdrop', `{ "isSignedWithActiveKey": true, "fromType": "contract", "symbol": "TSTNFT", "list": [
+        { "to": "aggroed", "ids": ["8"] }
+      ] }`)); // 18
+
+      block = {
+        refHiveBlockNumber: refBlockNumber,
+        refHiveBlockId: 'ABCD2',
+        prevRefHiveBlockId: 'ABCD1',
+        timestamp: '2018-06-01T00:00:00',
+        transactions,
+      }
+
+      await fixture.sendBlock(block);
+
+      const blockInfo = await fixture.database.getLatestBlockInfo();
+      const txs = blockInfo.transactions;
+
+      assertError(txs[0],  'you must use a custom_json signed with your active key');
+      assertError(txs[1],  'invalid symbol'); // doesn't exist
+      assertError(txs[2],  'invalid symbol'); // illegal name
+      assertError(txs[3],  'exceeded airdrop transactions limit'); // too many accounts
+      assertError(txs[4],  'exceeded airdrop transactions limit'); // too many total nfts
+      assertError(txs[5],  'invalid account be at index 2');
+      assertError(txs[6],  'invalid nft ids array for account bennierex at index 1'); // not an array
+      assertError(txs[7],  'invalid nft ids array for account bennierex at index 1'); // empty array
+      assertError(txs[8],  'invalid nft ids array for account bennierex at index 0'); // array size > params.maxTransactionsPerAccount
+      assertError(txs[9],  'invalid nft ids array for account bennierex at index 0'); // array items wrong type
+      assertError(txs[10], 'invalid nft ids array for account bennierex at index 0'); // array items not valid ids
+      assertError(txs[11], 'airdrop list contains duplicate nfts');
+      assertError(txs[12], 'cannot airdrop nfts that are delegated or not owned by this account'); // owned by other account
+      assertError(txs[13], 'cannot airdrop nfts that are delegated or not owned by this account'); // delegated
+      assertError(txs[14], 'invalid startBlockNumber'); // wrong type
+      assertError(txs[15], 'invalid startBlockNumber'); // lte current blocknumber
+      assertError(txs[16], 'you must have enough tokens to cover the airdrop fee');
+      assert.strictEqual(JSON.parse(txs[18].logs).errors[1], 'could not secure NFTs');
 
       resolve();
     })


### PR DESCRIPTION
# NFT Airdrops Smart Contract

## Description
This Smart Contract allows NFT's to be airdropped, much like the Airdrops Contract for tokens. This way, a substantial amount of NFT's can be transferred to many different accounts, without having to manually create each transaction.

## Usage
The NFT Airdrop Contract accepts a similar payload to that of the token Airdrops Contract. You specify the NFT symbol and a list of destination accounts. For each account, a list of NFT ID's needs to be provided that will be transferred to that account during the airdrop process.

### Example payload
```json
"symbol": "TUNZ",
"list":[
  {"to": "bait002", "ids":["11", "12"]},
  {"to": "aggroed", "ids": ["13", "6", "4"]},
  {"to": "bennierex", "ids":["39"]},
  {"to": "cryptomancer", "ids":["16"]},
  {"to": "nftmarket", "toType": "contract", "ids": ["8", "9", "10"]}
],
"startBlockNumber": 10000005,
"softFail": false
```

The optional parameter `startBlockNumber` allows a user to specify the earliest Hive-Engine block number the airdrop distribution will start. However, if other airdrops are still processing at that time, the actual start of the distribution might be delayed until there is a slot available.

Setting the optional parameter `softFail` to `false` will fail the airdrop upon the first transfer error (if any). The default value of `true` continues the airdrop process in case any NFT transfer errors occur. In both cases, after the airdrop finishes, any NFT's still locked in the contract will be released and transferred back to the initiator of the airdrop.

[documentation](https://github.com/bennierex/steemsmartcontracts-wiki/blob/0c1d032d4299501b93a577620601024b043fd6e8/NFT-Airdrops-Contract.md)

## Design considerations
The NFT Airdrops Contract tries to limit the amount of processing time required, by splitting larger airdrops across several blocks. The `tick`-action processes the pending airdrops in order. Several parameters have been made available to tweak the limits and processing load:

- `feePerTransaction`  
  Sets the fee (`UTILITY_TOKEN_SYMBOL`) required to be paid per NFT transaction.
- `maxTransactionsPerAirdrop`  
  Sets the maximum number of NFT's that can be airdropped in a single airdrop.
- `maxTransactionsPerAccount`  
  Sets the maximum number of NFT's that can be airdropped to a single account.
- `maxTransactionsPerBlock`  
  Sets the maximum transactions that can be processed each block. Setting this to a too low value will cause airdrops with many transactions to take a long time to complete. If more than one airdrop is processed in a single block (see `maxAirdropsPerBlock`), the transaction limit is spread evenly over all the airdrops. Even if some of the airdrops do not use up all transactions.
- `maxAirdropsPerBlock`  
  Sets the maximum number of airdrops that can be processed in a single block. See also `maxTransactionsPerBlock` on how this affects the processing of pending airdrops.
- `processingBatchSize`  
  This setting is used internally when transferring NFT's to/from the contract. It is important to keep this setting at or below the `MAX_NUM_NFTS_OPERABLE` constant of the NFT Smart Contract, or else NFT airdrops with more transactions than the limit imposed by the NFT Smart Contract will fail.

## Caveats
- In its current form, the NFT contract doesn't allow for a third-party contract to send NFT's through another contract. This means the account calling the third-party contract action needs to own the NFT instances, not the contract itself. However, the contract has support for this built in, so if the NFT contract would be updated to support this, there should be no changes required to this contract.

- The amount of NFT's that can be airdropped in one airdrop is virtually 'unlimited', but we're limited by the maximum size of a `custom_json` operation on the Hive blockchain. A possible workaround could be to split the payload and authorization between an `comment` op and a `custom_json` op, but that would add a lot of complexity to the contract. Also I couldn't find confirmation on the enforced maximum size of both operations on the Hive blockchain.
