### PR TITLE
Add IPv6 Support For Witnesses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steemsmartcontracts",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/plugins/P2P.js
+++ b/plugins/P2P.js
@@ -9,6 +9,7 @@ const SHA256 = require('crypto-js/sha256');
 const enchex = require('crypto-js/enc-hex');
 const dhive = require('@hiveio/dhive');
 const axios = require('axios');
+const net = require('node:net');
 const { Queue } = require('../libs/Queue');
 const { IPC } = require('../libs/IPC');
 const { Database } = require('../libs/Database');
@@ -222,7 +223,11 @@ const proposeRound = async (witness, round, retry = 0) => {
         round,
       },
     };
-    const url = `http://${witnessRec.IP}:${witnessRec.P2PPort}/p2p`;
+    let witIP = witnessRec.IP;
+    if (net.isIPv6(witIP)){
+      witIP = `[${witIP}]`;
+    }
+    const url = `http://${witIP}:${witnessRec.P2PPort}/p2p`;
 
     console.log(url);
     const response = await axios({


### PR DESCRIPTION
Currently witnesses don't have the ability to communicate with IPv6 witnesses due to malformed URL. 

```
2022-06-27 23:16:22 error: [P2P] Error posting to h-e / round 747286 / Error: connect ENETUNREACH 0.0.10.42:5001
2022-06-28 00:03:05 info: [P2P] http://2602:fb95:1::3:5001/p2p
```

The proper form is to add []'s around the v6 address to signify that it's a v6 address and not a port. This does that. @4Ykw found the issue.