### PR TITLE
Add lastVerifiedBlockNumber to getStatus request

### DIFF
--- a/plugins/JsonRPCServer.js
+++ b/plugins/JsonRPCServer.js
@@ -62,6 +62,11 @@ async function generateStatus() {
         result.firstBlockNumber = firstBlock?.blockNumber;
       }
 
+      const witnessParams = await database.findOne({ contract: 'witnesses', table: 'params', query: {} });
+      if (witnessParams && witnessParams.lastVerifiedBlockNumber) {
+        result.lastVerifiedBlockNumber = witnessParams.lastVerifiedBlockNumber;
+      }
+
       resolve(result);
     } catch (error) {
       reject(error);


### PR DESCRIPTION
This change adds the `lastVerifiedBlockNumber` to the `getStatus` request, by fetching it from the `witnesses` `params` table and adding it if present. I think this is rather useful to immediately check the state of hive-engine nodes, without having to perform a second request.