### PR TITLE
Fix HF26 breaking change for beneficiaries in Streamer.js

### DIFF
--- a/plugins/Streamer.js
+++ b/plugins/Streamer.js
@@ -144,6 +144,10 @@ const parseTransactions = (refBlockNumber, block) => {
               && extensions[0] && extensions[0].length > 1
               && extensions[0][1].beneficiaries) {
               beneficiaries = extensions[0][1].beneficiaries; // eslint-disable-line
+            } else if (extensions
+              && extensions[0] && extensions[0].value
+              && extensions[0].value.beneficiaries) {
+              beneficiaries = extensions[0].value.beneficiaries; // eslint-disable-line
             }
 
             sscTransactions = [


### PR DESCRIPTION
In HF26 the form beneficiaries are handled has changed (breaking change), which results in hive-engine nodes diverging, due to the beneficiaires not being parsed correctly.
Before the beneficiary format was the following:
```
"extensions": [
    [
      0,
      {
        "beneficiaries": [
          {
            "account": "alinares",
            "weight": 300
          },
          {
            "account": "hiveonboard",
            "weight": 100
          },
          {
            "account": "tipu",
            "weight": 100
          }]
      }]
  ]
}]
],
```

and after HF26:
```
"extensions": [
    {
      "type": "comment_payout_beneficiaries",
      "value": {
        "beneficiaries": [
          {
            "account": "alinares",
            "weight": 300
          },
          {
            "account": "hiveonboard",
            "weight": 100
          },
          {
            "account": "tipu",
            "weight": 100
          }]
      }
    }]
}]
],
```

The change adds an additional if case parsing the new beneficiary format.