### PR TITLE
Add ability to verify transactions from witness_actions.js

### DIFF
--- a/witness_action.js
+++ b/witness_action.js
@@ -35,10 +35,10 @@ function awaitValidation(trxID, tries = 1) {
       const parsedLogs = JSON.parse(res.data.result.logs);
       if (parsedLogs.errors) {
         // eslint-disable-next-line no-console
-        console.log(`Failed registration with reason "${parsedLogs.errors[0]}", your trx id: ${trxID}`);
+        console.log(`Failed action with reason "${parsedLogs.errors[0]}", your trx id: ${trxID}`);
       } else {
         // eslint-disable-next-line no-console
-        console.log(`Successfully registered, transaction id is ${trxID}`);
+        console.log(`Successfull, transaction id is ${trxID}`);
       }
     } else {
       if (tries >= 4) {

--- a/witness_action.js
+++ b/witness_action.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const axios = require('axios');
 const dhive = require('@hiveio/dhive');
 const program = require('commander');
 const packagejson = require('./package.json');
@@ -16,6 +17,53 @@ const {
 const extRPCNodePort = Number(String(process.env.RPCNODEPORT)) || rpcNodePort;
 const extP2PPort = Number(String(process.env.P2PPORT)) || p2pPort;
 
+program
+  .option('-v, --verify', 'verify transaction on hive-engine', false)
+  .option('-e, --engineNode [url]', 'verify with given hive-engine node', 'https://api.hive-engine.com/rpc')
+  .parse(process.argv);
+
+let { engineNode } = program;
+const { verify } = program;
+
+engineNode = engineNode.replace(/\/$/, '');
+
+function awaitValidation(trxID, tries = 1) {
+  axios.post(`${engineNode}/blockchain`, {
+    jsonrpc: '2.0', id: 0, method: 'getTransactionInfo', params: { txid: trxID },
+  }).then((res) => {
+    if (res.data.result) {
+      const parsedLogs = JSON.parse(res.data.result.logs);
+      if (parsedLogs.errors) {
+        // eslint-disable-next-line no-console
+        console.log(`Failed registration with reason "${parsedLogs.errors[0]}", your trx id: ${trxID}`);
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(`Successfully registered, transaction id is ${trxID}`);
+      }
+    } else {
+      if (tries >= 4) {
+        // eslint-disable-next-line no-console
+        console.log(`Successful broadcast but could not verify, trx id: ${trxID}`);
+        return;
+      }
+      setTimeout(() => {
+        awaitValidation(trxID, tries + 1);
+      }, 4000);
+    }
+  }).catch((err) => {
+    // eslint-disable-next-line no-console
+    console.log(err);
+    if (tries >= 4) {
+      // eslint-disable-next-line no-console
+      console.log(`Successful broadcast but could not verify, trx id: ${trxID}`);
+      return;
+    }
+    setTimeout(() => {
+      awaitValidation(trxID, tries + 1);
+    }, 4000);
+  });
+}
+
 function broadcastWitnessAction(contractAction, contractPayload) {
   const client = new dhive.Client(streamNodes[0]);
   const transaction = {
@@ -30,8 +78,12 @@ function broadcastWitnessAction(contractAction, contractPayload) {
   };
 
   client.broadcast.json(transaction, privateSigningKey).then((res) => {
-    // eslint-disable-next-line no-console
-    console.log(`Successful, trx id: ${res.id}`);
+    if (verify) {
+      awaitValidation(res.id);
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(`Successful, trx id: ${res.id}`);
+    }
   }).catch((err) => {
     // eslint-disable-next-line no-console
     console.error('Error', err);


### PR DESCRIPTION
Appending -v to `witness_actions.js` will let user choose to verify their transaction, and with -e they can specify an engine node to verify against.