### PR TITLE
Increase witness pay

### DIFF
--- a/contracts/inflation.js
+++ b/contracts/inflation.js
@@ -14,16 +14,15 @@ actions.createSSC = async () => {
 
 actions.issueNewTokens = async () => {
   if (api.sender !== 'null') return;
-  // 100k tokens per year = 11.41552511 tokens per hour (an hour = 1200 blocks)
-  const nbTokens = '11.41552511';
 
   // issue tokens to HIVE_ENGINE_ACCOUNT (100k/year)
+  // 100k tokens per year = 11.41552511 tokens per hour (an hour = 1200 blocks)
   await api.executeSmartContract('tokens', 'issue',
-    { symbol: UTILITY_TOKEN_SYMBOL, quantity: nbTokens, to: HIVE_ENGINE_ACCOUNT });
+    { symbol: UTILITY_TOKEN_SYMBOL, quantity: '11.41552511', to: HIVE_ENGINE_ACCOUNT });
 
-  // issue tokens to "witnesses" contract (100k/year)
+  // issue tokens to "witnesses" contract (200k/year)
   await api.executeSmartContract('tokens', 'issueToContract',
-    { symbol: UTILITY_TOKEN_SYMBOL, quantity: nbTokens, to: 'witnesses' });
+    { symbol: UTILITY_TOKEN_SYMBOL, quantity: '22.83105022', to: 'witnesses' });
 
   // establish utility token DTFs
   if (api.refHiveBlockNumber === 56977200) {

--- a/contracts/witnesses.js
+++ b/contracts/witnesses.js
@@ -8,8 +8,8 @@ const NB_WITNESSES = NB_TOP_WITNESSES + NB_BACKUP_WITNESSES;
 const NB_WITNESSES_SIGNATURES_REQUIRED = 14;
 const MAX_ROUNDS_MISSED_IN_A_ROW = 3; // after that the witness is disabled
 const MAX_ROUND_PROPOSITION_WAITING_PERIOD = 40; // number of blocks
-const NB_TOKENS_TO_REWARD = '0.00951293'; // inflation.js tokens per block
-const NB_TOKENS_NEEDED_BEFORE_REWARDING = '0.04756465'; // 5x to reward
+const NB_TOKENS_TO_REWARD = '0.01902586'; // inflation.js tokens per block
+const NB_TOKENS_NEEDED_BEFORE_REWARDING = '0.0951293'; // 5x to reward
 // eslint-disable-next-line no-template-curly-in-string
 const UTILITY_TOKEN_SYMBOL = "'${CONSTANTS.UTILITY_TOKEN_SYMBOL}$'";
 // eslint-disable-next-line no-template-curly-in-string
@@ -795,7 +795,9 @@ actions.proposeRound = async (payload) => {
             const schedule = schedules[index];
             // reward the witness that help verifying this round
             if (rewardWitnesses === true) {
-              await api.transferTokens(schedule.witness, UTILITY_TOKEN_SYMBOL, NB_TOKENS_TO_REWARD, 'user');
+              await api.executeSmartContract('tokens', 'stakeFromContract', {
+                to: schedule.witness, symbol: UTILITY_TOKEN_SYMBOL, quantity: NB_TOKENS_TO_REWARD,
+              });
             }
             await api.db.remove('schedules', schedule);
           }

--- a/test/witnesses.js
+++ b/test/witnesses.js
@@ -37,6 +37,7 @@ const tokensContractPayload = setupContractPayload('tokens', './contracts/tokens
 const miningContractPayload = setupContractPayload('mining', './contracts/mining.js');
 const tokenfundsContractPayload = setupContractPayload('tokenfunds', './contracts/tokenfunds.js');
 const nftauctionContractPayload = setupContractPayload('nftauction', './contracts/nftauction.js');
+const inflationContractPayload = setupContractPayload('inflation', './contracts/inflation.js');
 const witnessesContractPayload = setupContractPayload('witnesses', './contracts/witnesses.js',
     (contractCode) => contractCode.replace(/NB_TOP_WITNESSES = .*;/, 'NB_TOP_WITNESSES = 4;').replace(/MAX_ROUND_PROPOSITION_WAITING_PERIOD = .*;/, 'MAX_ROUND_PROPOSITION_WAITING_PERIOD = 20;').replace(/NB_WITNESSES_SIGNATURES_REQUIRED = .*;/, 'NB_WITNESSES_SIGNATURES_REQUIRED = 3;'));
 
@@ -1186,12 +1187,13 @@ describe('witnesses', function () {
       });
   });
 
-  it('verifies a block with liquid pay', (done) => {
+  it('verifies a block with staked pay', (done) => {
     new Promise(async (resolve) => {
       
       await fixture.setUp();
       let transactions = [];
       transactions.push(new Transaction(37899120, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(tokensContractPayload)));
+      transactions.push(new Transaction(37899120, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'update', JSON.stringify(inflationContractPayload)));
       transactions.push(new Transaction(37899120, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(miningContractPayload)));
       transactions.push(new Transaction(37899120, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(tokenfundsContractPayload)));
       transactions.push(new Transaction(37899120, fixture.getNextTxId(), CONSTANTS.HIVE_ENGINE_ACCOUNT, 'contract', 'deploy', JSON.stringify(nftauctionContractPayload)));
@@ -1363,7 +1365,7 @@ describe('witnesses', function () {
       }
 
       for (i = 0; i < schedules.length; i += 1) {
-        await tableAsserts.assertUserBalances({ account: schedules[i].witness, symbol: CONSTANTS.UTILITY_TOKEN_SYMBOL, balance: "0.00951293", stake: "0"});
+        await tableAsserts.assertUserBalances({ account: schedules[i].witness, symbol: CONSTANTS.UTILITY_TOKEN_SYMBOL, balance: "0", stake: "0.01902586"});
       }
 
       resolve();


### PR DESCRIPTION
This PR doubles BEE inflation for witness pay from 100k BEE per year to 200k BEE per year, and also changes payouts to give staked tokens rather than liquid tokens.