### PR TITLE
Run a divergence check before registering witnesses

### DIFF
--- a/find_divergent_block.js
+++ b/find_divergent_block.js
@@ -93,6 +93,7 @@ function printBlockDiff(block, mainBlock) {
 }
 
 async function findDivergentBlock() {
+  let exitCode = 0;
   const {
     databaseURL,
     databaseName,
@@ -114,11 +115,13 @@ async function findDivergentBlock() {
 
     if (!mainBlock) {
       console.log(`failed to fetch block ${block._id} from ${node}`);
+      exitCode = 3;
     } else if (mainBlock.hash === block.hash) {
       console.log('ok');
     } else {
       console.log(`head block divergent from ${node}`);
       console.log(`hash should be ${mainBlock.hash} is ${block.hash}`);
+      exitCode = 2;
     }
   } else {
     let low = 0;
@@ -148,14 +151,17 @@ async function findDivergentBlock() {
       console.log('ok');
     } else if (high !== low) {
       console.log('not caught up or error fetching block');
+      exitCode = 1;
     } else {
       console.log('### high block');
       printBlockDiff(block, mainBlock);
       console.log(`divergent block id at ${high}`);
+      exitCode = 2;
     }
   }
 
   database.close();
+  process.exit(exitCode);
 }
 
 findDivergentBlock();

--- a/witness_action.js
+++ b/witness_action.js
@@ -104,7 +104,7 @@ program
   .command('register')
   .action(() => {
     if (!skipDiverganceCheck) {
-      exec(`node find_divergent_block.js -n ${engineNode}`).on('exit', (code) => {
+      exec(`node find_divergent_block.js -h -n ${engineNode}`).on('exit', (code) => {
         if (code != 0) {
           // eslint-disable-next-line no-console
           console.log(`A divergent block was found, not registering. Run node find_divergent -n ${engineNode} to learn where.`)


### PR DESCRIPTION
The scrip to find divergence will run before registering a witness. Can be skipped by using option -s. Uses head only comparison for speed.