### PR TITLE
Update Config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
     "chainId": "mainnet-hive",
     "rpcNodePort": 5000,
     "p2pPort": 5001,
-    "databaseURL": "mongodb://localhost:27017",
+    "databaseURL": "mongodb://127.0.0.1:27017",
     "databaseName": "hsc",
     "blocksLogFilePath": "./blocks.log",
     "javascriptVMTimeout": 10000,
@@ -10,7 +10,6 @@
         "https://api.deathwing.me",
         "https://rpc.ecency.com",
         "https://hived.emre.sh",
-        "https://api.hive.blog",
         "https://api.openhive.network"
     ],
     "startHiveBlock": 41967000,


### PR DESCRIPTION
Remove api.hive.blog from config as testing is done on it and has caused problems in the past. 
Change mongodb database url to 127.0.0.1 as for some reason localhost doesn't seem to work on ipv6 only systems for some reason whereas 127.0.0.1 works on both dual stacked and ipv6 only.
